### PR TITLE
fix: Remove release target for now

### DIFF
--- a/rules/rules_task/BUILD.bazel
+++ b/rules/rules_task/BUILD.bazel
@@ -1,6 +1,4 @@
 load("@rules_task//tools:defs.bzl", "compile_pip_requirements")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:semantic-release/package_json.bzl", semantic_release_bin = "bin")
 load(":defs.bzl", "cmd", "task")
 
 package(default_visibility = ["//visibility:public"])
@@ -15,27 +13,4 @@ compile_pip_requirements(
     extra_args = ["--allow-unsafe"],
     requirements_in = "requirements.in",
     requirements_txt = "requirements.txt",
-)
-
-semantic_release_bin.semantic_release_binary(
-    name = "semantic-release_bin",
-    log_level = "debug",
-)
-
-task(
-    name = "release",
-    cmds = [
-        cmd.shell(
-            cmd.executable(":semantic-release_bin"),
-            "$CLI_ARGS",
-        ),
-    ],
-    cwd = "$(dirname $(readlink -f $RELEASERC))",
-    env = {
-        "RELEASERC": cmd.file(".releaserc"),
-        "BAZEL_BINDIR": ".",
-    },
-)
-
-npm_link_all_packages(
 )

--- a/rules/rules_task/MODULE.bazel
+++ b/rules/rules_task/MODULE.bazel
@@ -31,27 +31,3 @@ pip.parse(
 )
 
 use_repo(pip, "pip")
-
-# ------------------------------------ rules_js ------------------------------------ #
-bazel_dep(name = "aspect_rules_js", version = "1.32.6")
-
-npm = use_extension(
-    "@aspect_rules_js//npm:extensions.bzl",
-    "npm",
-)
-
-npm.npm_translate_lock(
-    name = "npm",
-    # Need to configure link_workspace otherwise invocation from setup workspace does not work
-    link_workspace = "rules_task",
-    pnpm_lock = "//:pnpm-lock.yaml",
-    verify_node_modules_ignored = "//:.bazelignore",
-)
-
-use_repo(npm, "npm")
-
-bazel_dep(name = "rules_nodejs", version = "6.0.1")
-
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-
-node.toolchain(node_version = "18.17.1")


### PR DESCRIPTION
ref #571 

Trying to use `rules_task` from another repository now results in this error:

```
INFO: Invocation ID: e8351898-f967-4c4e-854e-9332a999beff
ERROR: /workspaces/data-platform/meltano/BUILD.bazel:265:5: error loading package '@rules_task//': Unable to find package for @npm//:semantic-release/package_json.bzl: The repository '@npm' could not be resolved: Repository '@npm' is not defined. and referenced by '//meltano:kerk_runner'
ERROR: Analysis of target '//meltano:kerk' failed; build aborted: 
INFO: Elapsed time: 3.174s
INFO: 0 processes.
ERROR: Build failed. Not running target
FAILED: Build did NOT complete successfully (56 packages loaded, 276 targets configured)
    currently loading: @rules_task//
    Fetching repository @pip_jinja2; starting
    Fetching repository @pip_bazel_runfiles; starting
```

Currently the rules_js setup is not necessary as the release is run in a GitHub actions job (and not BuildBuddy)