### PR TITLE
fix: Prevent publish git from breaking if there are no changes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -213,6 +213,8 @@ task(
         "export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME",
         "export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL",
         "git add .",
+        "export CHANGES_TO_COMMIT=$(git diff-index --quiet HEAD && echo false || echo true)",
+        "if [ $CHANGES_TO_COMMIT = false ]; then echo 'Nothing to commit, working tree clean. Exitting.'; exit 0; fi",
         "git commit -m 'chore(release_manager): update release files'",
         # Disable credential.helper to ensure GIT_ASKPASS is used and not cached
         # Force https to ensure GIT_ASKPASS is used and we can use al alternative username


### PR DESCRIPTION
ref #603 