### PR TITLE
fix(spacelift): Remove log file if already exists

### DIFF
--- a/tools/spacelift/bin/spacetail
+++ b/tools/spacelift/bin/spacetail
@@ -47,6 +47,11 @@ readonly TS_TAILSCALED_EXTRA_ARGS
 if [[ ${ACTION} == "up" ]]; then
 	echo "spacetail: Bringing tailscale up"
 
+	LOG_FILE=/home/spacelift/tailscaled.log
+
+	# Remove the log file if already present
+	rm -f "${LOG_FILE}"
+
 	# With massive thanks to containerboot
 	# https://github.com/tailscale/tailscale/blob/main/cmd/containerboot/main.go
 
@@ -54,7 +59,7 @@ if [[ ${ACTION} == "up" ]]; then
 	nohup tailscaled \
 		--state=mem: --statedir="${TF_VAR_spacelift_workspace_root}/tailscale-state" \
 		--tun=userspace-networking \
-		${TS_TAILSCALED_EXTRA_ARGS} 2>/home/spacelift/tailscaled.log &
+		${TS_TAILSCALED_EXTRA_ARGS} 2>"${LOG_FILE}" &
 
 	sleep 1 # FIXME: grep tailscaled output somehow instead of this?
 


### PR DESCRIPTION
Fixes problem in Spacelift which happens after running `spacetail up` two times in the same container:

```
[01JG4ABG78GMSSN54F7JR7TEQA] Running 5 custom hooks...
[01JG4ABG78GMSSN54F7JR7TEQA] Applying changes...
spacetail: Bringing tailscale up
/usr/local/bin/spacetail: line 54: /home/spacelift/tailscaled.log: cannot overwrite existing file
failed to connect to local tailscaled; it doesn't appear to be running
[01JG4ABG78GMSSN54F7JR7TEQA] Ansible finished with exit code 1 when applying changes
[01JG4ABG78GMSSN54F7JR7TEQA] Uploading the list of managed resources...
[01JG4ABG78GMSSN54F7JR7TEQA] Could not read the status file: stat /mnt/workspace/source/ansible/.spacelift/artifacts/apply/status: no such file or directory
```

Removing the log file fixes this!