### PR TITLE
Add Codex CI stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,10 @@ Examples:
 - configmap-env.yaml
 - secret-db.yaml
 - cronjob-cleanup.yaml
+
+### Code Formatting & Checking
+
+This repo uses the [Trunk CLI](https://docs.trunk.io/code-quality/code-quality)
+for consistent formatting and linting. Run `trunk fmt` to automatically format
+your changes and `trunk check` to run the configured linters.
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,6 @@ tasks:
     cmds:
       - mkdocs gh-deploy --clean
 
-
   tools:spacelift:build:
     desc: Build and push the Spacelift image
     dir: tools/spacelift

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,10 @@ includes:
     taskfile: ./stacks/provisioner/Taskfile.yml
     dir: ./stacks/provisioner
 
+  stacks:codex:
+    taskfile: ./stacks/codex/Taskfile.yml
+    dir: .
+
   3rdparty:
     taskfile: ./3rdparty/Taskfile.yml
     dir: .

--- a/stacks/codex/Taskfile.yml
+++ b/stacks/codex/Taskfile.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+tasks:
+  setup:
+    desc: Prepare the Codex CI environment
+    cmds:
+      - eval "$(stacks/codex/setup.sh)"

--- a/stacks/codex/setup.sh
+++ b/stacks/codex/setup.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Install direnv
 ( curl -sfL https://direnv.net/install.sh | bash ) >&2
 
 # Install direnv into the Bash shell
+# shellcheck disable=SC2016
 echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
 
 # Allow the current project
 direnv allow >&2
 
 # Ensure Trunk CLI is installed
-( trunk install ) >&2
+trunk install >&2
 
 # Print direnv hook to stdout to be eval'ed by the calling process
-echo "$(direnv hook bash)"
+direnv hook bash
 
 # Print current envrc variables to stdout to be eval'ed by the calling process
-echo "$(direnv exec / direnv export bash)"
+direnv exec / direnv export bash

--- a/stacks/codex/setup.sh
+++ b/stacks/codex/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Install direnv
+( curl -sfL https://direnv.net/install.sh | bash ) >&2
+
+# Install direnv into the Bash shell
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+
+# Allow the current project
+direnv allow >&2
+
+# Ensure Trunk CLI is installed
+( trunk install ) >&2
+
+# Print direnv hook to stdout to be eval'ed by the calling process
+echo "$(direnv hook bash)"
+
+# Print current envrc variables to stdout to be eval'ed by the calling process
+echo "$(direnv exec / direnv export bash)"


### PR DESCRIPTION
## Summary
- add a new stack `codex`
- include a setup script that installs and configures direnv
- eager load Trunk CLI in the setup script
- document running `trunk fmt` and `trunk check`
- expose a Taskfile for running the codex setup
- register the new stack in the repo Taskfile

## Testing
- `trunk fmt` *(fails: npm error could not determine executable to run)*
- `trunk check` *(fails: npm error could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6859263f03e483338c8eed3cb3092b80