### PR TITLE
fix: Correct macOS capitalization typo in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Focused applications built using the libraries. Examples:
 Environment-specific deployments of apps and libs. Examples:
 
 - `stacks/enigma/`: Talos-based Kubernetes cluster deployment
-- `stacks/devenv/`: Local MacOS-based dev environment
+- `stacks/devenv/`: Local macOS-based dev environment
 - `stacks/provisioner/`: PiKVM machine provisioned using Ansible
 
 ### `third_party/`


### PR DESCRIPTION
## Summary
- Fixed inconsistent capitalization of "MacOS" to "macOS" in AGENTS.md to align with Apple's style guide
- Ensures consistency throughout the documentation

## Test plan
- [x] Verified typo is fixed in AGENTS.md line 29
- [x] Confirmed consistent macOS capitalization throughout the document

🤖 Generated with [Claude Code](https://claude.ai/code)