### PR TITLE
fix: Correct typo in PiKVM blog post description

### DIFF
--- a/docs/02_blog/deploying-pikvm-7-lessons-you-already-know.md
+++ b/docs/02_blog/deploying-pikvm-7-lessons-you-already-know.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying PiKVM: 7 Lessons You Already Know"
-description: Reaquiantance with valuable devops lessons through deploying PiKVM in various ways.
+description: Reacquaintance with valuable devops lessons through deploying PiKVM in various ways.
 date: 2025-01-09 10:43:00
 publish: true
 slug: deploying-pikvm-7-lessons-you-already-know


### PR DESCRIPTION
## Summary
- Fixed typo "Reaquiantance" to "Reacquaintance" in the PiKVM deployment blog post description

## Test plan
- [x] Verified the typo has been corrected in `docs/02_blog/deploying-pikvm-7-lessons-you-already-know.md`
- [x] No functional changes, purely a documentation typo fix

🤖 Generated with [Claude Code](https://claude.ai/code)