### PR TITLE
feat(coder-devcontainer): add NX_KEY environment variable support

### DIFF
--- a/.nx/version-plans/version-plan-1758775822420.md
+++ b/.nx/version-plans/version-plan-1758775822420.md
@@ -1,0 +1,5 @@
+---
+coder-devcontainer: patch
+---
+
+Add NX_KEY environment variable support


### PR DESCRIPTION
## Summary
- Add NX_KEY environment variable to Coder devcontainer configuration
- Follow the same pattern as existing HA_TOKEN implementation
- Fetch the key from 1Password vault at `op://setup-devenv/NX_KEY/credential`

## Changes
- Added 1Password data source for NX_KEY item
- Extract NX_KEY credential in locals
- Added validation check to ensure NX_KEY exists
- Created coder_env resource to expose NX_KEY to the agent

## Test plan
- [ ] Terraform validation passes
- [ ] CI checks pass
- [ ] NX_KEY is properly exposed in Coder workspaces

🤖 Generated with Claude Code