### PR TITLE
refactor(terraform): migrate check blocks to postconditions in coder-devcontainer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,16 +64,16 @@ Use consistent environment variables:
 Format: `<kind>-<name>.yaml` (e.g., `deployment-app.yaml`, `service-app.yaml`)
 
 ### Terraform Best Practices
-Use `check` statements to validate `data` resources:
+Use `postconditions` in `data` resources to validate their state:
 ```hcl
 data "aws_instance" "example" {
   instance_id = "i-1234567890abcdef0"
-}
 
-check "instance_running" {
-  assert {
-    condition     = data.aws_instance.example.state == "running"
-    error_message = "Instance must be running"
+  lifecycle {
+    postcondition {
+      condition     = self.state == "running"
+      error_message = "Instance must be running"
+    }
   }
 }
 ```

--- a/libs/coder-devcontainer/main.tf
+++ b/libs/coder-devcontainer/main.tf
@@ -60,66 +60,67 @@ data "coder_workspace_owner" "me" {}
 # Ensure that a vault named "setup-devenv" exists in your 1Password account.
 data "onepassword_vault" "setup_devenv" {
   name = "setup-devenv"
+
+  lifecycle {
+    postcondition {
+      condition     = can(self.uuid)
+      error_message = "The 'setup-devenv' vault must exist in 1Password."
+    }
+  }
 }
 
 # Ensure that an item titled "claude-code" exists in the 'setup-devenv' vault.
 data "onepassword_item" "claude_code" {
   vault = data.onepassword_vault.setup_devenv.uuid
   title = "claude-code"
+
+  lifecycle {
+    postcondition {
+      condition     = try(self.credential, "") != ""
+      error_message = "The 'claude-code' item in 1Password must have a credential value with the OAuth token."
+    }
+  }
 }
 
 # Ensure that an item titled "github-devcontainer-agent" exists in the 'setup-devenv' vault.
 data "onepassword_item" "github_devcontainer_agent" {
   vault = data.onepassword_vault.setup_devenv.uuid
   title = "github-devcontainer-agent"
+
+  lifecycle {
+    postcondition {
+      condition     = try(self.credential, "") != ""
+      error_message = "The 'github-devcontainer-agent' item in 1Password must have a credential value with the GitHub token."
+    }
+  }
 }
 
 # Ensure that an item titled "haos-api" exists in the 'setup-devenv' vault.
 data "onepassword_item" "haos_api" {
   vault = data.onepassword_vault.setup_devenv.uuid
   title = "haos-api"
+
+  lifecycle {
+    postcondition {
+      condition     = try(self.credential, "") != ""
+      error_message = "The 'haos-api' item in 1Password must have a password field with the Home Assistant API token."
+    }
+  }
 }
 
 # Ensure that an item titled "NX_KEY" exists in the 'setup-devenv' vault.
 data "onepassword_item" "nx_key" {
   vault = data.onepassword_vault.setup_devenv.uuid
   title = "NX_KEY"
-}
 
-check "onepassword_vault" {
-  assert {
-    condition     = can(data.onepassword_vault.setup_devenv.uuid)
-    error_message = "The 'setup-devenv' vault must exist in 1Password."
+  lifecycle {
+    postcondition {
+      condition     = try(self.credential, "") != ""
+      error_message = "The 'NX_KEY' item in 1Password must have a credential value with the NX key."
+    }
   }
 }
 
-check "claude_code_credential" {
-  assert {
-    condition     = local.claude_code_token != ""
-    error_message = "The 'claude-code' item in 1Password must have a credential value with the OAuth token."
-  }
-}
-
-check "github_token_credential" {
-  assert {
-    condition     = local.github_token != ""
-    error_message = "The 'github-devcontainer-agent' item in 1Password must have a credential value with the GitHub token."
-  }
-}
-
-check "ha_token_credential" {
-  assert {
-    condition     = local.ha_token != ""
-    error_message = "The 'haos-api' item in 1Password must have a password field with the Home Assistant API token."
-  }
-}
-
-check "nx_key_credential" {
-  assert {
-    condition     = local.nx_key != ""
-    error_message = "The 'NX_KEY' item in 1Password must have a credential value with the NX key."
-  }
-}
 
 data "coder_parameter" "system_prompt" {
   name         = "system_prompt"


### PR DESCRIPTION
## Summary
- Replace check blocks with lifecycle postconditions in OnePassword data resources
- Postconditions provide better validation and error messaging for data resources
- Update CLAUDE.md to reflect new best practice of using postconditions

## Changes Made
- Migrated 5 check blocks to postconditions in `libs/coder-devcontainer/main.tf`
- Updated CLAUDE.md with new Terraform best practice example
- Validated configuration with `terraform validate`

## Test Plan
- [x] Terraform validation passes
- [x] Configuration syntax is correct  
- [ ] CI checks pass
- [ ] Template can be deployed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)