### PR TITLE
fix: correct image path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ This is my personal blog where I write about my experiences, failures, successes
 
 ## About Me
 
-![About Me](./docs/images/about-me.jpeg)
+![About Me](./apps/docs/images/about-me.jpeg)
 
 I am a passionate developer with a strong focus on delivering business value. I’m good at learning new languages, technologies and tools to innovatively solve new and existing problems. I have substantial subject matter experience in security, securing systems, data and CI/CD. I’m a natural problem solver with an easy personality who likes to get things done.


### PR DESCRIPTION
## Summary
Fixed the incorrect image path in README.md from `./docs/images/about-me.jpeg` to `./apps/docs/images/about-me.jpeg`

The image was moved to the apps/docs directory structure but the README wasn't updated to reflect the new path.

## Test plan
- [x] Verified the image file exists at the correct path
- [x] Updated the markdown image reference

🤖 Generated with [Claude Code](https://claude.ai/code)