### PR TITLE
feat(devenv): add Coder Desktop and Motion apps for macOS

### DIFF
--- a/libs/devenv/files/.chezmoidata/packages.yaml
+++ b/libs/devenv/files/.chezmoidata/packages.yaml
@@ -31,6 +31,8 @@ packages:
       - github
       - finicky
       - obs
+      - coder
+      - motion
   linux:
     apt_packages:
       - git


### PR DESCRIPTION
## Summary
- Add Coder Desktop app to Homebrew cask packages
- Add Motion app to Homebrew cask packages

## Test plan
- [ ] Verify packages.yaml includes `coder` and `motion` casks
- [ ] Run `nx test devenv` to validate configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)