### PR TITLE
feat(devenv): disable nx console auto-install

### DIFF
--- a/libs/devenv/files/dot_nx/ide.json
+++ b/libs/devenv/files/dot_nx/ide.json
@@ -1,0 +1,3 @@
+{
+  "auto_install_console": false
+}

--- a/libs/devenv/goss.yaml
+++ b/libs/devenv/goss.yaml
@@ -282,6 +282,20 @@ file:
     contents:
       - github.com
 
+  '{{.Env.HOME}}/.nx':
+    title: Nx configuration directory exists
+    exists: true
+    filetype: directory
+
+  '{{.Env.HOME}}/.nx/ide.json':
+    title: Nx IDE configuration exists to disable auto-install console
+    meta:
+      url: https://github.com/nrwl/nx/issues/31668#issuecomment-3306509489
+    exists: true
+    filetype: file
+    contents:
+      - auto_install_console
+
 process:
   dockerd:
     title: Docker daemon is running inside container (Docker-in-Docker)


### PR DESCRIPTION
## Summary

- Adds `.nx/ide.json` configuration to disable automatic Nx Console extension installation
- Prevents unwanted VSCode extension prompts when running nx commands
- Includes goss tests to verify the configuration file exists and contains correct settings

## Test plan

- [x] Created `.nx/ide.json` via Chezmoi in devenv project
- [x] Added goss tests for `.nx` directory and `ide.json` file
- [ ] CI tests pass

## References

- Fixes https://github.com/nrwl/nx/issues/31668#issuecomment-3306509489

🤖 Generated with [Claude Code](https://claude.com/claude-code)