### PR TITLE
feat(devenv): add Claude desktop to macOS Homebrew packages

### DIFF
--- a/.nx/version-plans/version-plan-1759740583778.md
+++ b/.nx/version-plans/version-plan-1759740583778.md
@@ -1,0 +1,5 @@
+---
+devenv: patch
+---
+
+feat(devenv): add Claude desktop to macOS Homebrew packages

--- a/libs/devenv/files/.chezmoidata/packages.yaml
+++ b/libs/devenv/files/.chezmoidata/packages.yaml
@@ -30,6 +30,7 @@ packages:
       - obsidian
       - gimp
       - chatgpt
+      - claude
       - github
       - finicky
       - obs

--- a/package-lock.json
+++ b/package-lock.json
@@ -9766,7 +9766,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- Add Claude desktop cask to the devenv package configuration for macOS

## Changes
- Added `claude` to the list of Homebrew casks in `libs/devenv/files/.chezmoidata/packages.yaml`
- This enables installation of Claude desktop application on macOS via Homebrew

## Test plan
- [ ] Verify the package.yaml syntax is correct
- [ ] Confirm that the cask name `claude` is valid in Homebrew
- [ ] Test on macOS to ensure Claude desktop installs correctly via `nx test devenv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)