### PR TITLE
feat(oneshot): add validation commands before CI push

### DIFF
--- a/.claude/commands/oneshot.md
+++ b/.claude/commands/oneshot.md
@@ -8,15 +8,19 @@ After implementing the prompt, follow these steps:
 
 1. Check the current branch using `git branch --show-current`
    - If on main branch: Create a new git branch for the change using a descriptive name based on the work done
-2. Commit all changes with an appropriate commit message
-3. Push the branch to the remote repository
-4. Check if a PR already exists using `gh pr view --json url,state`
+2. Run validation commands:
+   - Run `nx run-many -t release_plan_test package_test` to validate releases and packages
+   - Run `trunk check` to verify code quality standards
+   - If either command fails, fix the issues before proceeding
+3. Commit all changes with an appropriate commit message
+4. Push the branch to the remote repository
+5. Check if a PR already exists using `gh pr view --json url,state`
    - If a PR exists: Report the existing PR URL and skip PR creation
    - If no PR exists: Create a GitHub pull request for the change with a clear title and description
-5. Report the GitHub pull request URL
-6. Monitor CI status using `gh pr checks --watch`
-7. If there are problems with the CI, analyze the failures, make fixes, commit and push the changes, then return to step 6
-8. Once CI passes successfully, report completion
+6. Report the GitHub pull request URL
+7. Monitor CI status using `gh pr checks --watch`
+8. If there are problems with the CI, analyze the failures, make fixes, commit and push the changes, then return to step 7
+9. Once CI passes successfully, report completion
 
 Important notes:
 - Use `git status` and `git diff` to understand what changes were made

--- a/package-lock.json
+++ b/package-lock.json
@@ -9766,7 +9766,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- Add `nx run-many -t release_plan_test package_test` validation before pushing to CI
- Add `trunk check` code quality verification before pushing to CI
- Fix package-lock.json drift in picomatch devOptional flag

## Changes
This PR enhances the `/oneshot` command workflow to run validation commands before pushing to CI. This ensures that:
1. Release plans are valid and packages can be tested
2. Code meets quality standards via trunk check
3. Issues are caught early before CI runs

The validation commands are inserted as step 2 in the oneshot workflow, running after implementation but before committing changes.

## Test plan
- [x] Verified oneshot.md syntax and workflow steps
- [x] Tested nx run-many command execution
- [x] Fixed package-lock.json drift issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)