### PR TITLE
fix(docs): remove trailing whitespace from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is my personal blog where I write about my experiences, failures, successes and other things that interest me. It also houses documentation for all of my experiments and projects. I hope you find something useful here.
 
-[Check out the docs to start exploring!](https://vgijssel.github.io/setup/) 
+[Check out the docs to start exploring!](https://vgijssel.github.io/setup/)
 
 ## About Me
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9766,7 +9766,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- Removed trailing whitespace from markdown link line in README.md
- Updated package-lock.json to fix npm install consistency issue

## Test plan
- [x] Verified README.md renders correctly
- [x] Ran `nx run-many -t release_plan_test package_test` - passed
- [x] Ran `trunk check` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)