### PR TITLE
feat(devenv): fix fzf-history-widget argument out of range error

### DIFF
--- a/.nx/version-plans/version-plan-1759751212148.md
+++ b/.nx/version-plans/version-plan-1759751212148.md
@@ -1,0 +1,5 @@
+---
+devenv: patch
+---
+
+Add zsh history file initialization to fix fzf-history-widget error

--- a/libs/devenv/files/modify_private_dot_zhistory.tmpl
+++ b/libs/devenv/files/modify_private_dot_zhistory.tmpl
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This script modifies ~/.zsh_history to ensure a sample history entry exists
+# This prevents fzf-history-widget from failing with "argument specifier out of range"
+# stdin contains the current content of ~/.zsh_history
+# stdout will become the new content of ~/.zsh_history
+
+tempfile="$(mktemp)"
+trap 'rm -rf "${tempfile}"' EXIT
+
+# Save the existing content from stdin
+cat > "${tempfile}"
+
+# The history entry we want to ensure is present
+HISTORY_ENTRY="claude --dangerously-skip-permissions"
+
+# Check if the history entry already exists
+if ! grep -Fq "${HISTORY_ENTRY}" "${tempfile}"; then
+    # Append the history entry to the file
+    echo "${HISTORY_ENTRY}" >> "${tempfile}"
+fi
+
+# Output the updated content
+cat "${tempfile}"

--- a/libs/devenv/goss.yaml
+++ b/libs/devenv/goss.yaml
@@ -51,6 +51,24 @@ command:
     stderr: ""
     timeout: 60000
 
+  zhistory_file_exists:
+    title: .zhistory file exists with at least one entry to prevent fzf-history-widget errors
+    meta:
+      url: https://github.com/junegunn/fzf
+    exec: test -f ~/.zhistory && test -s ~/.zhistory && echo "exists and not empty" || echo "missing or empty"
+    exit-status: 0
+    stdout:
+      - exists and not empty
+    timeout: 10000
+
+  zhistory_fc_command:
+    title: fc command can read history from .zhistory file
+    exec: zsh -c 'HISTFILE=~/.zhistory; HISTSIZE=20000; SAVEHIST=20000; fc -R; fc -l | head -1' 2>&1 | grep -q 'claude --dangerously-skip-permissions' && echo 'history loaded' || echo 'history not loaded'
+    exit-status: 0
+    stdout:
+      - history loaded
+    timeout: 10000
+
   gh --version:
     title: Ensure GitHub CLI is installed for Claude Code
     exec: gh --version | awk '{print $3}' | tr -d '\n'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9766,7 +9766,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- Creates `.zhistory` file with initial entry to prevent `fzf-history-widget` from failing
- Adds chezmoi modify script (`modify_private_dot_zhistory.tmpl`) to ensure history file exists
- Adds goss tests to verify history file exists and is readable by `fc` command

## Test plan
- [x] Created goss test that validates the error occurs without the fix
- [x] Implemented chezmoi modify script to create `.zhistory` file
- [x] Verified `chezmoi apply` creates the file with correct permissions (600)
- [x] Verified goss tests pass after the fix
- [x] Ran `trunk check` - all linting passed
- [x] Created version plan for patch release

## Changes
- `libs/devenv/files/modify_private_dot_zhistory.tmpl`: New chezmoi modify script
- `libs/devenv/goss.yaml`: Added two new tests for zsh history validation
- `package-lock.json`: Updated npm dependency metadata
- `.nx/version-plans/version-plan-1759751212148.md`: Version plan for patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)