### PR TITLE
fix(devenv): re-enable VSCode extension installation

### DIFF
--- a/.nx/version-plans/version-plan-re-enable-vscode-extensions.md
+++ b/.nx/version-plans/version-plan-re-enable-vscode-extensions.md
@@ -1,0 +1,7 @@
+---
+devenv: patch
+---
+
+Re-enable VSCode extension installation after upstream issue resolution
+
+The VSCode CLI hanging issue (https://github.com/microsoft/vscode/issues/269737) has been resolved, so we can now re-enable the automatic installation of VSCode extensions from the extensions.json file.

--- a/libs/devenv/files/run_onchange_install-vscode-extensions.sh.tmpl
+++ b/libs/devenv/files/run_onchange_install-vscode-extensions.sh.tmpl
@@ -8,17 +8,11 @@ set -euo pipefail
 
 EXT_FILE="{{ $extensions_file }}"
 
-# TEMPORARY: VSCode extension installation disabled due to CLI hanging on macOS
-# See: https://github.com/microsoft/vscode/issues/269737
-echo "⚠️  VSCode extension installation is temporarily disabled"
-echo "    Issue: VSCode CLI hangs on macOS runners"
-echo "    See: https://github.com/microsoft/vscode/issues/269737"
-echo "    Extensions list: $EXT_FILE"
+echo "📦 Installing VSCode extensions from $EXT_FILE"
 
-# TODO: Re-enable when VSCode issue is resolved
-# jq -r '.recommendations[]' "$EXT_FILE" | while read -r extension; do
-#     echo "➕ Installing $extension..."
-#     code --install-extension "$extension" --force
-# done
+jq -r '.recommendations[]' "$EXT_FILE" | while read -r extension; do
+    echo "➕ Installing $extension..."
+    code --install-extension "$extension" --force
+done
 
-echo "✅ Script completed (extensions not installed)"
+echo "✅ VSCode extensions installed successfully"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9766,7 +9766,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary

Re-enables automatic VSCode extension installation after the upstream CLI hanging issue has been resolved.

## Changes

- ✅ Removed temporary workaround code that disabled extension installation
- ✅ Restored automatic installation from `.vscode/extensions.json`
- ✅ Updated user-facing messages to reflect re-enabled functionality
- ✅ Created version plan for patch release

## Background

The VSCode CLI was experiencing hanging issues on macOS runners (see [microsoft/vscode#269737](https://github.com/microsoft/vscode/issues/269737)). As a temporary workaround, we disabled automatic extension installation. The upstream issue has now been resolved, so we can safely re-enable this feature.

## Test Plan

- [x] Validated with `nx run-many -t release_plan_test package_test`
- [x] Code quality verified with `trunk check`
- [ ] CI pipeline passes all checks
- [ ] Manual testing in devcontainer environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)