### PR TITLE
fix(cluster-networking): allow k8s_gateway egress to the kube-apiserver

### DIFF
--- a/apps/cluster-networking/k8s-gateway/values-prod.yaml
+++ b/apps/cluster-networking/k8s-gateway/values-prod.yaml
@@ -3,6 +3,11 @@
 # Keycloak OIDC redirects) so the Service stays ClusterIP. The ClusterIP is
 # pinned so kube-dns can forward `enigma.vgijssel.nl` to a stable target.
 k8s-gateway:
+  # Cozystack tenant namespaces gate egress to the kube-apiserver via a
+  # CiliumNetworkPolicy that selects on this label. Without it the
+  # controller can't watch Ingress/Service resources.
+  customLabels:
+    policy.cozystack.io/allow-to-apiserver: "true"
   service:
     type: ClusterIP
     clusterIP: 10.96.53.53


### PR DESCRIPTION
## Summary

- Cozystack tenant namespaces ship a CiliumNetworkPolicy (`allow-to-apiserver`) that only permits egress to `10.96.0.1:443` from pods labelled `policy.cozystack.io/allow-to-apiserver=true`.
- Without the label, the k8s_gateway controller's list/watch against Ingress/Service resources times out, and it returns `could not sync required resources` for every query (verified in pod logs on the live deploy).
- Fix: add the label via `customLabels` in `values-prod.yaml`. The upstream chart propagates `customLabels` to both Deployment and Pod metadata.

## Test plan

- [x] Reproduced without the label: `dig keycloak.enigma.vgijssel.nl` via kube-dns → empty response, k8s_gateway logs show `plugin/k8s_gateway: could not sync required resources`.
- [ ] After merge, wait for ArgoCD to roll the new pod template, then re-run the dig from `tenant-prod-clusternetworking` and confirm A record returns `192.168.50.100`.
- [ ] Confirm Keycloak OIDC flow resolves its issuer hostname correctly.