### PR TITLE
feat(internal-networking): tag generated gateway ingresses for k8s-gateway to ignore

### DIFF
--- a/libs/internal-networking/templates/clusterpolicy-gateway-ingress.yaml
+++ b/libs/internal-networking/templates/clusterpolicy-gateway-ingress.yaml
@@ -54,6 +54,11 @@ spec:
             labels:
               # Add internal-networking label for external-dns to track
               internal-networking: "true"
+              # k8s_gateway (apps/cluster-networking/k8s-gateway) honors this
+              # label and skips the resource. Without it, the generated
+              # gateway ingress (public IP 46.224.93.115) would also land in
+              # in-cluster DNS answers for the same hostname.
+              k8s-gateway.dns/ignore: "true"
               app.kubernetes.io/managed-by: kyverno
               kyverno.io/generated-by: generate-gateway-ingress
             annotations:


### PR DESCRIPTION
## Summary

The Kyverno policy that mirrors tenant-* ingresses into the gateway IngressClass (public egress `46.224.93.115`) already stamps the generated resources with `internal-networking=true` so the Cloudflare-backed `external-dns` picks them up for public DNS.

Add `k8s-gateway.dns/ignore=true` alongside it so the new in-cluster `k8s_gateway` **skips** these generated resources — otherwise a query for e.g. `keycloak.enigma.vgijssel.nl` returns both the internal VLAN ingress IP (`192.168.50.100`) and the public one (`46.224.93.115`), which we don't want for intra-cluster traffic.

This mirrors the allow/denylist split that the retired `external-dns-pihole` HelmRelease used via `--label-filter=internal-networking!=true`, but centralised at the source of the generated ingresses so we don't have to duplicate the rule in k8s_gateway config.

## Test plan

- [ ] After merge, Kyverno regenerates the `-gateway` ingresses with the new label.
- [ ] From a pod in `tenant-prod-clusternetworking`, `dig keycloak.enigma.vgijssel.nl` should return only `192.168.50.100` (no `46.224.93.115`).
- [ ] Public DNS (`dig @1.1.1.1 keycloak.enigma.vgijssel.nl`) should still return `46.224.93.115` — external-dns is unaffected.