### PR TITLE
fix(devenv): route claude.ai to HackerOne work profile

### DIFF
--- a/libs/devenv/files/dot_finicky.js
+++ b/libs/devenv/files/dot_finicky.js
@@ -40,7 +40,7 @@ export default {
       match: "https://claude.ai/*",
       browser: {
         name: "Google Chrome",
-        profile: "vgijssel.nl",
+        profile: "HackerOne.com",
       },
     },
     {


### PR DESCRIPTION
## Summary
Finicky was routing `claude.ai` URLs to the personal `vgijssel.nl` Chrome profile. This changes the handler to use the `HackerOne.com` work profile, matching the other HackerOne handlers in the config.

## Change
`libs/devenv/files/dot_finicky.js`: `claude.ai` handler profile `vgijssel.nl` → `HackerOne.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)