### PR TITLE
feat(pikvm): enable NetBird native SSH server

### DIFF
--- a/apps/pikvm/deploy.py
+++ b/apps/pikvm/deploy.py
@@ -41,6 +41,8 @@ from pyinfra.operations import files, pacman, server, systemd
 from pyinfra_custom.facts import (
     NetbirdConnected,
     NetbirdDnsDisabled,
+    NetbirdServerSshAllowed,
+    NetbirdSshRootEnabled,
     NetbirdVersion,
     OpenBaoSecret,
     PacmanUpgradablePackages,
@@ -324,7 +326,19 @@ with rootfs.writable(changed_if=netbird_needs_rw):
         )
 
 
-# ── netbird up (DNS enabled) + config-change restart (Task 6) ────────────────────
+# ── netbird up (DNS + native SSH enabled) + config-change restart (Task 6) ───────
+# NATIVE SSH: NetBird's built-in SSH server is enabled here (`allow_server_ssh=True`)
+# with root login permitted (`enable_ssh_root=True`) so the box stays reachable as
+# `root` the same way it is today, but authenticated by NetBird/IdP identity (JWT) over
+# the wt0 overlay instead of a static authorized_keys entry. Both flags are persisted by
+# NetBird in /var/lib/netbird/default.json (ServerSSHAllowed / EnableSSHRoot), so they
+# are passed explicitly on every `netbird up` to make the desired state deterministic,
+# and the reconcile below is gated on facts that read those persisted values so a
+# converged box makes no changes. JWT auth is left ON (we do NOT pass --disable-ssh-auth);
+# access is still governed by an Access Control policy in the NetBird dashboard, so the
+# SSH server does no useful thing until that policy exists. The LAN root authorized_keys
+# fallback (bootstrap slice above) is intentionally kept as a break-glass path.
+#
 # DNS is ENABLED here (`disable_dns=False`). The stock PiKVM guide passes
 # `--disable-dns` to stop NetBird writing /etc/resolv.conf on the read-only rootfs, but
 # that assumes NetBird's *file* DNS backend. This box runs systemd-resolved (active,
@@ -354,6 +368,10 @@ with rootfs.writable(changed_if=netbird_needs_rw):
 netbird_connected = host.get_fact(NetbirdConnected)
 # Current persisted DNS setting; only meaningful once registered (False before).
 dns_currently_disabled = host.get_fact(NetbirdDnsDisabled)
+# Current persisted native-SSH settings; both False before registration (no config yet),
+# which correctly drives the reconcile to turn them on.
+ssh_server_allowed = host.get_fact(NetbirdServerSshAllowed)
+ssh_root_enabled = host.get_fact(NetbirdSshRootEnabled)
 
 if not netbird_connected:
     # First bring-up: start services, register with DNS enabled, persist state.
@@ -370,9 +388,11 @@ if not netbird_connected:
     # netbird.up passes the setup key via per-command _env ($NB_SETUP_KEY) -- never in
     # argv or --dry.
     netbird.up(
-        name="NetBird: register with setup key (DNS enabled)",
+        name="NetBird: register with setup key (DNS + native SSH enabled)",
         setup_key=_secret("netbird_setup_key"),
         disable_dns=False,
+        allow_server_ssh=True,
+        enable_ssh_root=True,
     )
     with rootfs.writable(changed_if=True):
         server.shell(
@@ -394,7 +414,8 @@ else:
             "systemctl restart netbird@netbird.service; "
             "sleep 1; "
             "netbird down || true; "
-            "netbird up --disable-dns=false; "
+            "netbird up --disable-dns=false "
+            "--allow-server-ssh=true --enable-ssh-root=true; "
             "rw; cp -a /tmp/netbird-state/. /root/netbird-state/; ro"
             "'",
         ],
@@ -404,6 +425,8 @@ else:
             or overlay_script.did_change()
             or netbird_needs_install
             or dns_currently_disabled
+            or not ssh_server_allowed
+            or not ssh_root_enabled
         ),
     )
 

--- a/libs/pyinfra-custom/src/pyinfra_custom/facts/__init__.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/facts/__init__.py
@@ -3,7 +3,7 @@
 - :class:`~pyinfra_custom.facts.openbao.OpenBaoSecret` — one OpenBao KV field, fetched
   via the ``hvac`` SDK on the control machine (never transmitted to the target host).
 - :mod:`~pyinfra_custom.facts.netbird` — NetBird client state (version / connected /
-  DNS), each guarded by ``requires_command('netbird')``.
+  DNS / SSH server / SSH root), each guarded by ``requires_command('netbird')``.
 - :class:`~pyinfra_custom.facts.pacman.PacmanUpgradablePackages` — upgradable packages,
   guarded by ``requires_command('pacman')``.
 """
@@ -11,6 +11,8 @@
 from pyinfra_custom.facts.netbird import (
     NetbirdConnected,
     NetbirdDnsDisabled,
+    NetbirdServerSshAllowed,
+    NetbirdSshRootEnabled,
     NetbirdVersion,
 )
 from pyinfra_custom.facts.openbao import OpenBaoSecret, SecretsError
@@ -19,6 +21,8 @@ from pyinfra_custom.facts.pacman import PacmanUpgradablePackages
 __all__ = [
     "NetbirdConnected",
     "NetbirdDnsDisabled",
+    "NetbirdServerSshAllowed",
+    "NetbirdSshRootEnabled",
     "NetbirdVersion",
     "OpenBaoSecret",
     "PacmanUpgradablePackages",

--- a/libs/pyinfra-custom/src/pyinfra_custom/facts/netbird.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/facts/netbird.py
@@ -68,3 +68,47 @@ class NetbirdDnsDisabled(FactBase[bool]):
 
     def process(self, output: list[str]) -> bool:
         return any("true" in line.lower() for line in output)
+
+
+class NetbirdServerSshAllowed(FactBase[bool]):
+    """``True`` when NetBird's persisted config has ``ServerSSHAllowed: true``.
+
+    Drives the SSH-server-enable reconcile. Returns ``False`` before registration (the
+    config file does not exist yet), matching "SSH server not allowed".
+    """
+
+    default = bool  # bool() -> False
+
+    def requires_command(self, *args, **kwargs) -> str:
+        return "netbird"
+
+    def command(self) -> str:
+        return (
+            "grep -o '\"ServerSSHAllowed\"[^,]*' /var/lib/netbird/default.json "
+            "2>/dev/null || true"
+        )
+
+    def process(self, output: list[str]) -> bool:
+        return any("true" in line.lower() for line in output)
+
+
+class NetbirdSshRootEnabled(FactBase[bool]):
+    """``True`` when NetBird's persisted config has ``EnableSSHRoot: true``.
+
+    Drives the SSH-root-enable reconcile. Returns ``False`` before registration (the
+    config file does not exist yet), matching "root login not enabled".
+    """
+
+    default = bool  # bool() -> False
+
+    def requires_command(self, *args, **kwargs) -> str:
+        return "netbird"
+
+    def command(self) -> str:
+        return (
+            "grep -o '\"EnableSSHRoot\"[^,]*' /var/lib/netbird/default.json "
+            "2>/dev/null || true"
+        )
+
+    def process(self, output: list[str]) -> bool:
+        return any("true" in line.lower() for line in output)

--- a/libs/pyinfra-custom/src/pyinfra_custom/operations/netbird.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/operations/netbird.py
@@ -6,7 +6,12 @@ from pyinfra.api import StringCommand, operation
 
 
 @operation(is_idempotent=False)
-def up(setup_key: str | None = None, disable_dns: bool = False):
+def up(
+    setup_key: str | None = None,
+    disable_dns: bool = False,
+    allow_server_ssh: bool = False,
+    enable_ssh_root: bool = False,
+):
     """Run ``netbird up`` to register / (re)connect the peer.
 
     Args:
@@ -16,15 +21,29 @@ def up(setup_key: str | None = None, disable_dns: bool = False):
             an already-registered peer.
         disable_dns: passed through as ``--disable-dns=<true|false>``. NetBird persists
             this flag, so it must be set explicitly to flip it; ``False`` keeps DNS on.
+        allow_server_ssh: passed through as ``--allow-server-ssh=<true|false>`` to enable
+            NetBird's native SSH server on the peer. NetBird persists this in its config
+            (``ServerSSHAllowed``), so it is always set explicitly to make the desired
+            state deterministic.
+        enable_ssh_root: passed through as ``--enable-ssh-root=<true|false>`` to permit
+            root login on the native SSH server. Only meaningful when ``allow_server_ssh``
+            is ``True``; likewise persisted (``EnableSSHRoot``), so set explicitly.
 
     Not idempotent: ``netbird up`` on an already-connected peer is itself a no-op, but
     pyinfra cannot know that, so callers gate this with ``_if`` / a connected fact.
     """
-    flag = "true" if disable_dns else "false"
+    dns_flag = "true" if disable_dns else "false"
+    ssh_flag = "true" if allow_server_ssh else "false"
+    ssh_root_flag = "true" if enable_ssh_root else "false"
+    args = (
+        f"--disable-dns={dns_flag} "
+        f"--allow-server-ssh={ssh_flag} "
+        f"--enable-ssh-root={ssh_root_flag}"
+    )
     if setup_key is not None:
         yield StringCommand(
-            f'netbird up --setup-key "$NB_SETUP_KEY" --disable-dns={flag}',
+            f'netbird up --setup-key "$NB_SETUP_KEY" {args}',
             _env={"NB_SETUP_KEY": setup_key},
         )
     else:
-        yield StringCommand(f"netbird up --disable-dns={flag}")
+        yield StringCommand(f"netbird up {args}")

--- a/libs/pyinfra-custom/tests/test_facts.py
+++ b/libs/pyinfra-custom/tests/test_facts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pyinfra_custom.facts import (
     NetbirdConnected,
     NetbirdDnsDisabled,
+    NetbirdServerSshAllowed,
+    NetbirdSshRootEnabled,
     NetbirdVersion,
     PacmanUpgradablePackages,
 )
@@ -37,6 +39,26 @@ def test_netbird_dns_disabled_reads_flag():
     assert fact.process(['"DisableDNS":true']) is True
     assert fact.process(['"DisableDNS":false']) is False
     assert fact.process([]) is False
+
+
+def test_netbird_server_ssh_allowed_reads_flag():
+    fact = NetbirdServerSshAllowed()
+    assert fact.requires_command() == "netbird"
+    assert "ServerSSHAllowed" in fact.command()
+    assert fact.process(['"ServerSSHAllowed":true']) is True
+    assert fact.process(['"ServerSSHAllowed":false']) is False
+    assert fact.process([]) is False
+    assert NetbirdServerSshAllowed.default() is False
+
+
+def test_netbird_ssh_root_enabled_reads_flag():
+    fact = NetbirdSshRootEnabled()
+    assert fact.requires_command() == "netbird"
+    assert "EnableSSHRoot" in fact.command()
+    assert fact.process(['"EnableSSHRoot":true']) is True
+    assert fact.process(['"EnableSSHRoot":false']) is False
+    assert fact.process([]) is False
+    assert NetbirdSshRootEnabled.default() is False
 
 
 def test_pacman_upgradable_lists_nonblank_lines():

--- a/libs/pyinfra-custom/tests/test_operations.py
+++ b/libs/pyinfra-custom/tests/test_operations.py
@@ -23,6 +23,9 @@ def test_netbird_up_with_setup_key_uses_env_not_argv():
     assert "super-secret-key" not in raw
     assert "$NB_SETUP_KEY" in raw
     assert "--disable-dns=false" in raw
+    # SSH flags default off and are always emitted explicitly.
+    assert "--allow-server-ssh=false" in raw
+    assert "--enable-ssh-root=false" in raw
 
 
 def test_netbird_up_without_setup_key_has_no_env():
@@ -30,12 +33,33 @@ def test_netbird_up_without_setup_key_has_no_env():
     assert len(commands) == 1
     cmd = commands[0]
     assert cmd.connector_arguments.get("_env") is None
-    assert cmd.get_raw_value() == "netbird up --disable-dns=false"
+    assert cmd.get_raw_value() == (
+        "netbird up --disable-dns=false "
+        "--allow-server-ssh=false --enable-ssh-root=false"
+    )
 
 
 def test_netbird_up_disable_dns_true():
     commands = list(netbird.up._inner(setup_key=None, disable_dns=True))
-    assert commands[0].get_raw_value() == "netbird up --disable-dns=true"
+    assert commands[0].get_raw_value() == (
+        "netbird up --disable-dns=true "
+        "--allow-server-ssh=false --enable-ssh-root=false"
+    )
+
+
+def test_netbird_up_allow_server_ssh_and_root():
+    commands = list(
+        netbird.up._inner(
+            setup_key=None,
+            disable_dns=False,
+            allow_server_ssh=True,
+            enable_ssh_root=True,
+        )
+    )
+    assert commands[0].get_raw_value() == (
+        "netbird up --disable-dns=false "
+        "--allow-server-ssh=true --enable-ssh-root=true"
+    )
 
 
 # ── pikvm.htpasswd ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Switches the PiKVM (`apps/pikvm`) from static-key SSH to **NetBird's native SSH server**, so the box is reachable as `root` via NetBird/IdP identity (JWT) over the `wt0` overlay instead of a static `authorized_keys` entry.

## Changes

- **`libs/pyinfra-custom/.../operations/netbird.py`** — `netbird.up()` gains `allow_server_ssh` / `enable_ssh_root`, always emitted explicitly as `--allow-server-ssh=<t/f> --enable-ssh-root=<t/f>` (NetBird persists these in `default.json`, like `--disable-dns`, so they must be set explicitly to be deterministic).
- **`libs/pyinfra-custom/.../facts/netbird.py`** — new facts `NetbirdServerSshAllowed` / `NetbirdSshRootEnabled` read the persisted `ServerSSHAllowed` / `EnableSSHRoot` values from `/var/lib/netbird/default.json` to gate the reconcile.
- **`apps/pikvm/deploy.py`** — Task 6 registers/reconciles with SSH enabled; the reconcile `_if` guard fires when SSH is not yet on and stays a no-op once converged.
- Tests updated + added (`15 passed`), `trunk check` clean.

## Design notes

- `--enable-ssh-root=true` — kept because we log into this box as `root` today. This is the one security-relevant knob.
- JWT auth left **on** (did *not* pass `--disable-ssh-auth`) — access is governed by IdP identity + the dashboard policy, not a static key.
- The existing `NB_DISABLE_SSH_CONFIG=true` override is unrelated (client-side `~/.ssh/config` generation, which would fail on the read-only rootfs) — left as-is.
- **No port conflict**: NetBird binds its SSH server to the overlay IP only (`netbirdIP:22` → `:22022` via a NetBird-managed DNAT), so the host's existing `sshd` on `eth0:22` is untouched. The LAN root `authorized_keys` path is kept as break-glass.

## Follow-up (account-side, not in code)

SSH does nothing useful until an **Access Control policy** exists in the NetBird dashboard:
1. Access Control → Policies → Add Policy
2. Source = operator/admin group; Destination = the PiKVM peer's group
3. Protocol = **NetBird SSH**; map authorized groups → local `root` account

Then connect with `netbird ssh root@pikvm`.

## Test plan

- [x] `uv run --all-extras pytest` in `libs/pyinfra-custom` — 15 passed
- [x] `trunk check` clean on all changed files
- [ ] `moon run pikvm:apply -- --dry` (LAN inventory) then real apply
- [ ] Verify `netbird ssh root@pikvm` after creating the dashboard policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)