### PR TITLE
feat(network): reach Omada at omada.network.vgijssel.nl over NetBird

### DIFF
--- a/apps/network/src/external-dns/Chart.lock
+++ b/apps/network/src/external-dns/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: external-dns
+  repository: file://../../../../third_party/vendir/charts/external-dns
+  version: 1.19.0
+digest: sha256:5bb80b28f6af4522e9d240780d983aa2d38a9891edb8d19d9b553478083129b9
+generated: "2026-07-18T23:04:44.929274+02:00"

--- a/apps/network/src/external-dns/Chart.yaml
+++ b/apps/network/src/external-dns/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: external-dns
+description: external-dns (Cloudflare) publishing the pinned omada ClusterIP as omada.network.vgijssel.nl
+version: 1.0.0
+appVersion: 0.19.0
+dependencies:
+  - name: external-dns
+    version: 1.19.0
+    repository: file://../../../../third_party/vendir/charts/external-dns

--- a/apps/network/src/external-dns/fleet.yaml
+++ b/apps/network/src/external-dns/fleet.yaml
@@ -1,0 +1,21 @@
+# Portable Fleet bundle for external-dns on the network cluster. Fleet detects the umbrella
+# Chart.yaml here and deploys it with values.yaml, plus the sibling ExternalSecret template.
+# Needs the external-dns-cloudflare-api-token Secret (synced from OpenBao by the template
+# below); until that exists external-dns crash-loops on the missing token, expected during
+# bootstrap.
+#
+# network-ONLY. bin/fleet-apply applies every bundle globally, so target the network cluster
+# explicitly — this keeps external-dns (and its network-cluster txtOwnerId) off the secret
+# cluster. If the secret cluster ever needs its own external-dns it MUST declare a distinct
+# txtOwnerId, or the two clusters would treat each other's records as orphans and delete
+# them (a hard boundary observed with omada.network.vgijssel.nl).
+labels:
+  fleet.vgijssel.nl/bundle: network-external-dns
+defaultNamespace: external-dns
+helm:
+  releaseName: external-dns
+targetCustomizations:
+  - name: network
+    clusterSelector:
+      matchLabels:
+        cluster.vgijssel.nl/name: network

--- a/apps/network/src/external-dns/templates/externalsecret-external-dns.yaml
+++ b/apps/network/src/external-dns/templates/externalsecret-external-dns.yaml
@@ -1,0 +1,21 @@
+# Syncs the Cloudflare API token (Zone:Read + DNS:Edit) from OpenBao for external-dns to
+# manage omada.network.vgijssel.nl. Reuses kv/cloudflare#credential (the same token
+# cert-manager's DNS-01 solver uses). Requires kv/cloudflare#credential seeded in OpenBao.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-dns-cloudflare-api-token
+  namespace: external-dns
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: external-dns-cloudflare-api-token
+    creationPolicy: Owner
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: cloudflare
+        property: credential

--- a/apps/network/src/external-dns/values.yaml
+++ b/apps/network/src/external-dns/values.yaml
@@ -1,0 +1,38 @@
+# external-dns, Cloudflare provider, on the NETWORK cluster. Publishes the omada
+# controller's pinned ClusterIP as a grey-cloud (DNS-only) A record for
+# omada.network.vgijssel.nl, so every NetBird client (regardless of resolver — getaddrinfo,
+# dig, or DoH browsers) resolves the hostname to the ClusterIP and reaches Omada over the
+# mesh with a valid LE cert. See apps/network/src/omada/templates/service-omada.yaml.
+#
+# source=service + publish-internal-services makes external-dns publish ClusterIP Services;
+# it only touches Services carrying external-dns.alpha.kubernetes.io/hostname, so the omada
+# Service's annotation is the scope (no other Service is annotated). policy=sync lets it
+# create AND remove the records it owns. proxied defaults to false; the omada Service also
+# sets cloudflare-proxied=false explicitly (an orange-cloud record would hand back
+# Cloudflare edge IPs instead of the mesh-routable ClusterIP).
+#
+# The Cloudflare API token comes from the external-dns-cloudflare-api-token Secret
+# (templates/externalsecret-external-dns.yaml, synced from OpenBao kv/cloudflare#credential).
+# domainFilters + txtOwnerId scope external-dns to the vgijssel.nl zone and tag its TXT
+# ownership records to THIS cluster — the secret cluster's external-dns MUST use a different
+# owner id or the two would delete each other's records (historically observed).
+external-dns:
+  provider:
+    name: cloudflare
+  sources:
+    - service
+  policy: sync
+  registry: txt
+  txtOwnerId: network-cluster
+  domainFilters:
+    - vgijssel.nl
+  # Publish ClusterIP Services' cluster IPs (external-dns skips ClusterIP Services by
+  # default). Still gated to Services with the hostname annotation.
+  extraArgs:
+    - --publish-internal-services
+  env:
+    - name: CF_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: external-dns-cloudflare-api-token
+          key: api-token

--- a/apps/network/src/omada/templates/service-omada.yaml
+++ b/apps/network/src/omada/templates/service-omada.yaml
@@ -1,26 +1,42 @@
 # The ENTIRE Omada controller — admin UI/portal (HTTP/HTTPS) AND the device
 # adoption/management L4 ports — exposed over NetBird as a single *Network Resource*
-# (operator v1 stack). This replaces the BYOP reverse proxy entirely: the reverse proxy
-# could carry only the HTTPS admin UI as a NetBird-Only private service and CANNOT serve
-# Omada's raw TCP device ports on the current image (netbirdio/netbird#6400 makes mode=tcp
-# L4 services silently not bind on reverse-proxy 0.72.x, and the private-services feature
-# is 0.72-only, so no single proxy version served both). NetBird Networks (routing peer +
-# NBResource) forward all TCP/UDP at L3/L4, so one resource covers every port.
+# (operator v1 stack), reachable from mesh clients at its real hostname
+# omada.network.vgijssel.nl with a valid public cert.
 #
-# The netbird.io/expose annotation makes the operator create a domain-type NBResource
-# (address omada.omada.svc.cluster.local) on the `router` NBRoutingPeer's network
-# (apps/network/src/netbird-config/nbroutingpeer-router.yaml) plus an access policy from the
-# `homelab` group (the Mac + the pikvm routing peer) to it. Requires operator
-# ingress.allowAutomaticPolicyCreation=true. Omitting policy-protocol/policy-ports lets the
+# HOW THE HOSTNAME RESOLVES (approach validated in the omada-resolution spike):
+#   * netbird.io/expose makes the operator create a domain NBResource with address
+#     omada.omada.svc.cluster.local on the `router` NBRoutingPeer's network
+#     (apps/network/src/netbird-config/nbroutingpeer-router.yaml). The routing peer
+#     resolves that to THIS Service's ClusterIP and NetBird installs a /32 route to the
+#     ClusterIP on every `homelab` client. That route is IP-based, not name-based.
+#   * external-dns (apps/network/src/external-dns) publishes a grey-cloud (DNS-only)
+#     Cloudflare A record omada.network.vgijssel.nl -> this Service's ClusterIP, driven by
+#     the external-dns.alpha.kubernetes.io/hostname annotation below (only annotated
+#     ClusterIP Services are published, so this is self-scoping). Because every resolver
+#     (getaddrinfo, dig, DoH browsers) then returns the ClusterIP, and the ClusterIP already
+#     routes through the mesh, clients reach omada.network.vgijssel.nl over NetBird and hit
+#     the LE cert served on 8043 — no reverse proxy, no NetBird DNS zone, no split-brain.
+#     A specific A record shadows the *.vgijssel.nl wildcard (which otherwise CNAMEs to
+#     NetBird cloud). Off-mesh the ClusterIP is unroutable, so the service stays mesh-only.
+#
+# The ClusterIP is PINNED (spec.clusterIP below) to a static-band address in the
+# 10.96.0.0/12 service CIDR so it survives cluster rebuilds and external-dns always
+# publishes the same stable IP. clusterIP is immutable — changing it requires deleting and
+# recreating this Service.
+#
+# This replaces the BYOP reverse proxy entirely: the reverse proxy could carry only the
+# HTTPS admin UI as a NetBird-Only private service and CANNOT serve Omada's raw TCP device
+# ports on the current image (netbirdio/netbird#6400 makes mode=tcp L4 services silently
+# not bind on reverse-proxy 0.72.x, and the private-services feature is 0.72-only, so no
+# single proxy version served both). NetBird Networks (routing peer + NBResource) forward
+# all TCP/UDP at L3/L4, so one resource covers every port. Requires operator
+# ingress.allowAutomaticPolicyCreation=true; omitting policy-protocol/policy-ports lets the
 # auto-policy allow both TCP and UDP on all ports to homelab (all Omada traffic is trusted
 # homelab traffic); the routed ports are bound by this Service's port list below.
 #
-# The admin UI is reached over the mesh on 8043 (HTTPS); Omada serves the LE cert for
-# omada.network.vgijssel.nl there (certificate-omada.yaml, mounted at /cert), so mesh
-# clients get a trusted cert with no reverse proxy in the path. Physical Omada devices are
-# not NetBird clients: they resolve the public omada.network.vgijssel.nl name and route the
-# NetBird range through the pikvm routing peer on their LAN (custom domain + external-dns IP
-# sync are wired in follow-up tasks). This Service's ClusterIP is what the in-cluster
+# Physical Omada devices are not NetBird clients: they resolve the same public
+# omada.network.vgijssel.nl name (now a real A record) and route the NetBird range through
+# the pikvm routing peer on their LAN. This Service's ClusterIP is what the in-cluster
 # routing peer dials; the selector matches the omada-controller subchart pods exactly (a
 # mismatch leaves it with zero endpoints).
 apiVersion: v1
@@ -33,8 +49,16 @@ metadata:
     netbird.io/groups: omada
     netbird.io/policy: omada
     netbird.io/policy-source-groups: homelab
+    # external-dns publishes a grey-cloud (DNS-only) A record for this hostname pointing at
+    # the ClusterIP below. proxied=false is required — an orange-cloud record would return
+    # Cloudflare edge IPs instead of the mesh-routable ClusterIP.
+    external-dns.alpha.kubernetes.io/hostname: omada.network.vgijssel.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   type: ClusterIP
+  # Pinned, static-band ClusterIP (see header). Stable across rebuilds; external-dns
+  # publishes this exact address for omada.network.vgijssel.nl.
+  clusterIP: 10.96.0.20
   selector:
     app.kubernetes.io/name: omada-controller
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/apps/pikvm/files/goss.yaml
+++ b/apps/pikvm/files/goss.yaml
@@ -5,8 +5,10 @@
 #
 # The dns/addr resources below rely on goss seeing systemd-resolved's stub resolver
 # (127.0.0.53) -- goss-serve.service binds the stub resolv.conf into the unit so goss's
-# Go resolver traverses NetBird's split-DNS routing to *.svc.cluster.local. goss manages
-# its own per-check timeouts.
+# Go resolver sees the box-wide resolution: omada.network.vgijssel.nl is a public Cloudflare
+# A record pointing at Omada's pinned in-cluster ClusterIP (published by external-dns), and
+# that ClusterIP is routed over NetBird, so the checks exercise real mesh reachability. goss
+# manages its own per-check timeouts.
 command:
   # 1. NetBird management plane is connected (the mesh is up).
   netbird-connected:
@@ -15,35 +17,35 @@ command:
     stdout:
       - "Management: Connected"
 
-# 2. NetBird DNS resolves the in-cluster Omada Service name across the mesh.
+# 2. Omada's public hostname resolves (Cloudflare A -> pinned ClusterIP, mesh-routed).
 dns:
-  omada.omada.svc.cluster.local:
+  omada.network.vgijssel.nl:
     resolvable: true
 
-# 3. TCP reachability to the Omada controller on every documented TCP port, over NetBird
-#    cross-cluster routing (target is the in-cluster Service, not the public tailnet name).
+# 3. TCP reachability to the Omada controller on every documented TCP port, reached at its
+#    real hostname omada.network.vgijssel.nl over NetBird cross-cluster routing.
 #    Ports mirror apps/network/src/omada/templates/service-omada.yaml (TCP only -- the UDP
 #    27001/29810/19810 entries are L2-only discovery and cannot be connect-tested).
 addr:
-  tcp://omada.omada.svc.cluster.local:8088:      # manage-http
+  tcp://omada.network.vgijssel.nl:8088:      # manage-http
     reachable: true
-  tcp://omada.omada.svc.cluster.local:8043:      # manage-https
+  tcp://omada.network.vgijssel.nl:8043:      # manage-https
     reachable: true
-  tcp://omada.omada.svc.cluster.local:8843:      # portal-https
+  tcp://omada.network.vgijssel.nl:8843:      # portal-https
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29811:     # manager-v1
+  tcp://omada.network.vgijssel.nl:29811:     # manager-v1
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29812:     # adopt-v1
+  tcp://omada.network.vgijssel.nl:29812:     # adopt-v1
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29813:     # upgrade-v1
+  tcp://omada.network.vgijssel.nl:29813:     # upgrade-v1
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29814:     # manager-v2
+  tcp://omada.network.vgijssel.nl:29814:     # manager-v2
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29815:     # transfer-v2
+  tcp://omada.network.vgijssel.nl:29815:     # transfer-v2
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29816:     # rtty
+  tcp://omada.network.vgijssel.nl:29816:     # rtty
     reachable: true
-  tcp://omada.omada.svc.cluster.local:29817:     # device-monitor
+  tcp://omada.network.vgijssel.nl:29817:     # device-monitor
     reachable: true
 
 # 4. The NetBird systemd instance is enabled (survives reboot) and running.


### PR DESCRIPTION
## Summary

Expose the Omada controller to NetBird clients at its **real hostname `omada.network.vgijssel.nl`** (valid Let's Encrypt cert, no reverse proxy in the path) instead of the in-cluster Service FQDN. Previously mesh clients reached Omada via `omada.omada.svc.cluster.local`, which the LE cert doesn't cover → TLS name mismatch.

Validated in a spike on the live `network` vcluster before productionizing.

## How it works

- **Pin the omada Service ClusterIP** to a static-band address (`10.96.0.20`) in the `10.96.0.0/12` service CIDR — stable across cluster rebuilds, and external-dns always publishes the same value. (`clusterIP` is immutable, so this required a one-time Service recreate, already applied.)
- **external-dns** (re-homed under `apps/network`, network-only, `txtOwnerId: network-cluster`) publishes a **grey-cloud (DNS-only) A record** `omada.network.vgijssel.nl → ClusterIP` via `--publish-internal-services`, scoped by the Service's `external-dns.alpha.kubernetes.io/hostname` annotation (only annotated ClusterIP Services are published).
- The existing `netbird.io/expose` NBResource keeps **routing the ClusterIP over the mesh**. Because every resolver (getaddrinfo, `dig`, DoH browsers) then returns the ClusterIP, and that IP is mesh-routed, clients reach `omada.network.vgijssel.nl` over NetBird and hit the matching cert — no NetBird DNS zone, no split-brain.
- **goss** pikvm health checks retargeted to `omada.network.vgijssel.nl` (dns + all TCP ports).

## Changes

- `apps/network/src/omada/templates/service-omada.yaml` — pin `clusterIP: 10.96.0.20`, add external-dns annotations, keep `netbird.io/expose`, rewrite header comment.
- `apps/network/src/external-dns/` (new bundle) — `Chart.yaml`, `Chart.lock`, `values.yaml`, `fleet.yaml` (network-only), `ExternalSecret` for the Cloudflare token.
- `apps/pikvm/files/goss.yaml` — switch omada checks to the public hostname + update comments.

## Verified live

- omada Service ClusterIP pinned to `10.96.0.20` (Helm/Fleet ownership preserved).
- Cloudflare authoritatively returns `omada.network.vgijssel.nl → 10.96.0.20`; public resolvers (1.1.1.1/8.8.8.8/9.9.9.9) agree — DNS-rebinding protection is a non-issue.
- Operator reconciled the NBResource + TCP/UDP policies (homelab → omada).
- Earlier in the spike, end-to-end `curl https://omada.network.vgijssel.nl:8043` returned **HTTP 200 with a verified cert** (`CN=omada.network.vgijssel.nl`).

## Known caveat (not DNS-related)

NetBird 0.75 routing-peer data-path reliability (lazy connection + DNS-route propagation) is intermittent in the OrbStack `network` vcluster and can leave clients without the `/32` route to the ClusterIP — this affects the pre-existing `omada.omada.svc.cluster.local` path identically and is orthogonal to this change. Durable fix: disable lazy connection at the NetBird account level. Avoid `rollout restart deploy/router` (re-enrolls the peer and destabilizes route propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)