### PR TITLE
feat(secret,network): pin k8s targets to their vind cluster via vcluster connect

### DIFF
--- a/apps/network/scripts/apply.sh
+++ b/apps/network/scripts/apply.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CLUSTER_NAME="${NETWORK_CLUSTER_NAME:-network}"
 FLEET_NS="fleet-local"
 EXPECTED_LABEL="network"
 
@@ -30,8 +31,19 @@ require() { command -v "$1" >/dev/null 2>&1 || {
   echo "ERROR: '$1' is required but not found" >&2
   exit 1
 }; }
+require vcluster
 require fleet
 require kubectl
+
+# ── Point kubectl at THIS cluster regardless of the ambient kube-context ──────
+# Select the vind docker driver (global, idempotent) and connect to the cluster,
+# which rewrites the active kube-context — so an externally-switched context can't
+# send the apply at the wrong cluster. start.sh already connects before it exec's
+# here, so this only matters for a standalone `network:apply`. The label guard below
+# stays the authoritative safety gate.
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)"
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}"
 
 # ── Safety guard: refuse to apply against the wrong / unlabelled cluster ──────
 actual_label="$(kubectl -n "${FLEET_NS}" get clusters.fleet.cattle.io local \

--- a/apps/network/scripts/netbird_auth.sh
+++ b/apps/network/scripts/netbird_auth.sh
@@ -32,6 +32,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
+CLUSTER_NAME="${NETWORK_CLUSTER_NAME:-network}"
 CONTEXT="${NETWORK_KUBE_CONTEXT:-vcluster-docker_network}"
 NB_NAMESPACE="${NB_NAMESPACE:-netbird}"
 REMOTE_BAO_ADDR="${REMOTE_BAO_ADDR:-https://openbao.secret.vgijssel.nl}"
@@ -42,9 +43,18 @@ require() { command -v "$1" >/dev/null 2>&1 || {
   echo "ERROR: '$1' is required but not found" >&2
   exit 1
 }; }
+require vcluster
 require kubectl
 require jq
 require bao
+
+# Point kubectl at the '${CLUSTER_NAME}' vind cluster regardless of the ambient
+# kube-context (select the docker driver + connect; idempotent). This makes the
+# active context this cluster; the explicit --context "${CONTEXT}" flags below still
+# pin every write to it belt-and-suspenders.
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)"
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}"
 
 # Load VAULT_TOKEN (secret-cluster root) from .env if not already exported.
 if [[ -z "${VAULT_TOKEN:-}" && -f "${REPO_ROOT}/.env" ]]; then

--- a/apps/secret/scripts/apply.sh
+++ b/apps/secret/scripts/apply.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CLUSTER_NAME="${SECRET_CLUSTER_NAME:-secret}"
 FLEET_NS="fleet-local"
 EXPECTED_LABEL="secret"
 
@@ -31,8 +32,19 @@ require() { command -v "$1" >/dev/null 2>&1 || {
   echo "ERROR: '$1' is required but not found" >&2
   exit 1
 }; }
+require vcluster
 require fleet
 require kubectl
+
+# ── Point kubectl at THIS cluster regardless of the ambient kube-context ──────
+# Select the vind docker driver (global, idempotent) and connect to the cluster,
+# which rewrites the active kube-context — so an externally-switched context can't
+# send the apply at the wrong cluster. start.sh already connects before it exec's
+# here, so this only matters for a standalone `secret:apply`. The label guard below
+# stays the authoritative safety gate.
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)"
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}"
 
 # ── Safety guard: refuse to apply against the wrong / unlabelled cluster ──────
 actual_label="$(kubectl -n "${FLEET_NS}" get clusters.fleet.cattle.io local \

--- a/apps/secret/scripts/auth.sh
+++ b/apps/secret/scripts/auth.sh
@@ -23,9 +23,19 @@ POD="${OPENBAO_POD:-openbao-0}"
 ROLE="${OPENBAO_ADMIN_ROLE:-admin}"
 SA="${OPENBAO_ADMIN_SA:-openbao-admin}"
 LOCAL_PORT="${LOCAL_PORT:-8200}"
+CLUSTER_NAME="${SECRET_CLUSTER_NAME:-secret}"
 
 require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required but not found" >&2; exit 1; }; }
+require vcluster
 require kubectl
+
+# Point kubectl at the '${CLUSTER_NAME}' vind cluster regardless of the ambient
+# kube-context (select the docker driver + connect; idempotent). Its output goes to
+# stderr so the `export` lines this script prints on stdout stay eval-clean
+# (`eval "$(moon run --log error secret:auth)"`).
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)" >&2
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}" >&2
 
 # Fail early if the SA / pod aren't there (wrong cluster/context, or not bootstrapped).
 if ! kubectl -n "${NS}" get serviceaccount "${SA}" >/dev/null 2>&1; then

--- a/apps/secret/scripts/forward.sh
+++ b/apps/secret/scripts/forward.sh
@@ -13,9 +13,17 @@ set -euo pipefail
 NS="${SECRET_NAMESPACE:-secret}"
 SVC="${OPENBAO_SERVICE:-openbao}"
 LOCAL_PORT="${LOCAL_PORT:-8200}"
+CLUSTER_NAME="${SECRET_CLUSTER_NAME:-secret}"
 
 require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required but not found" >&2; exit 1; }; }
+require vcluster
 require kubectl
+
+# Point kubectl at the '${CLUSTER_NAME}' vind cluster regardless of the ambient
+# kube-context (select the docker driver + connect; idempotent).
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)"
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}"
 
 CURRENT_CONTEXT="$(kubectl config current-context 2>/dev/null || echo "?")"
 echo "==> kubectl context: ${CURRENT_CONTEXT}"

--- a/apps/secret/scripts/netbird_proxy_auth.sh
+++ b/apps/secret/scripts/netbird_proxy_auth.sh
@@ -36,14 +36,22 @@ NB_API_URL="${NB_API_URL:-https://api.netbird.io}"
 KV_MOUNT="${KV_MOUNT:-kv}"
 KV_PROXY_PATH="${KV_PROXY_PATH:-secret-netbird-proxy}"
 PROXY_TOKEN_NAME="${PROXY_TOKEN_NAME:-secret.vgijssel.nl}"
+CLUSTER_NAME="${SECRET_CLUSTER_NAME:-secret}"
 
 require() { command -v "$1" >/dev/null 2>&1 || {
   echo "ERROR: '$1' is required but not found" >&2
   exit 1
 }; }
+require vcluster
 require kubectl
 require jq
 require curl
+
+# Point kubectl at the '${CLUSTER_NAME}' vind cluster regardless of the ambient
+# kube-context (select the docker driver + connect; idempotent).
+echo "==> Connecting to the '${CLUSTER_NAME}' vind cluster (vcluster connect)"
+vcluster use driver docker >/dev/null 2>&1 || true
+vcluster connect "${CLUSTER_NAME}"
 
 # Fail early if the SA / pod aren't there (wrong cluster/context, or not applied yet).
 if ! kubectl -n "${NS}" get serviceaccount "${SA}" >/dev/null 2>&1; then


### PR DESCRIPTION
## What

The k8s-facing Moon targets in `apps/secret` and `apps/network` previously ran against whatever kube-context happened to be **ambient**. This prefixes each with an idempotent `vcluster use driver docker` + `vcluster connect <cluster>` preamble so they always target the correct vind cluster regardless of the active context.

Scripts updated:

| Project | Script | Target |
|---|---|---|
| secret | `apply.sh` | `secret:apply` |
| secret | `auth.sh` | `secret:auth` |
| secret | `forward.sh` | `secret:forward` |
| secret | `netbird_proxy_auth.sh` | `secret:netbird_proxy_auth` |
| network | `apply.sh` | `network:apply` |
| network | `netbird_auth.sh` | `network:netbird_auth` |

## Why

An externally-switched kubeconfig context could otherwise send a command at the *wrong* vind cluster — the same class of cross-cluster clobber that took OpenBao down once. Connecting first makes each target self-targeting.

## Notes

- `start.sh` already connects (unchanged); `stop.sh` deletes by name (unchanged).
- The `apply.sh` label guard remains the authoritative safety gate — `vcluster connect` is defence-in-depth in front of it.
- `auth.sh` sends the connect output to stderr so its `export` lines stay eval-clean (`eval "$(moon run --log error secret:auth)"`).
- `network/netbird_auth.sh` keeps its explicit `--context` flags (belt-and-suspenders) on top of the new connect.

## Validation

Targets run directly against the live secret/network clusters (see PR checks / comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)