### PR TITLE
feat(netbird): self-heal watchdogs for wedged NetBird peer sessions

### DIFF
--- a/apps/network/src/eso-sidecar/cronjob-eso-sidecar-watchdog.yaml
+++ b/apps/network/src/eso-sidecar/cronjob-eso-sidecar-watchdog.yaml
@@ -1,0 +1,92 @@
+# Self-heal watchdog for the external-secrets netbird sidecar.
+#
+# WHY: the injected netbird native-sidecar (container `netbird` in deploy/external-secrets)
+# logs in only at pod start (SetupKey enrolment). If management forces a re-auth later — a host
+# VM suspend/resume, or a login expiry — it drops to SessionExpired/NeedsLogin and never
+# re-auths on its own. The ClusterSecretStore `openbao` then reports InvalidProviderConfig and
+# every OpenBao-backed ExternalSecret goes SecretSyncedError, silently, until someone runs
+# `kubectl rollout restart deploy/external-secrets` by hand.
+#
+# WHAT: every 5 min, exec `netbird status` in the sidecar. `netbird status` exits 0 even when
+# the session is dead, so the decision is made on the OUTPUT. On a terminal bad state we
+# rollout-restart the controller; the new pod re-injects the sidecar and re-enrolls with the
+# SetupKey. If exec fails (pod rolling / not ready) we skip the cycle so we never race an
+# in-flight restart. Mirrors apps/network/src/netbird-config/cronjob-router-watchdog.yaml.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netbird-eso-sidecar-watchdog
+  namespace: external-secrets
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: netbird-eso-sidecar-watchdog
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: watchdog
+              # alpine/kubectl (not registry.k8s.io/kubectl, which is distroless with no
+              # shell) — the watchdog logic runs in /bin/sh. Multi-arch, ~22MB. Pinned to the
+              # multi-arch index digest.
+              image: alpine/kubectl:1.35.0@sha256:862d86046bbcad03c252bbc10ab8bf893e7aa50aa7a20de8bfc46727dd645883
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  ns=external-secrets
+                  dep=external-secrets
+
+                  # netbird status exits 0 even when the session is dead, so decide on the
+                  # output. A non-zero exec means the pod is rolling / not ready — skip.
+                  if ! status="$(kubectl -n "$ns" exec "deploy/$dep" -c netbird -- netbird status 2>&1)"; then
+                    echo "watchdog: cannot reach $dep netbird sidecar (rolling / not ready); skipping this cycle"
+                    printf '%s\n' "$status"
+                    exit 0
+                  fi
+                  printf '%s\n' "$status"
+
+                  # Terminal states the daemon cannot recover from without re-running
+                  # `netbird up` (which only happens at pod start) -> recycle the controller.
+                  if printf '%s' "$status" | grep -qE 'Daemon status: (NeedsLogin|SessionExpired|LoginFailed)'; then
+                    echo "watchdog: $dep netbird sidecar session is dead -> kubectl rollout restart deploy/$dep"
+                    kubectl -n "$ns" rollout restart "deploy/$dep"
+                  else
+                    echo "watchdog: $dep netbird sidecar session healthy"
+                  fi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/network/src/eso-sidecar/fleet.yaml
+++ b/apps/network/src/eso-sidecar/fleet.yaml
@@ -4,6 +4,11 @@
 # cross-cluster secret path that replaces the old tailnet route. Mirrors the secret cluster's
 # jwks-gateway sidecar (apps/secret/src/jwks-gateway). See [[netbird-crosscluster-routing]].
 #
+# serviceaccount-eso-sidecar-watchdog.yaml + cronjob-eso-sidecar-watchdog.yaml add a self-heal
+# watchdog that recycles the ESO controller when its netbird sidecar wedges in
+# NeedsLogin/SessionExpired (e.g. after a host VM suspend/resume), which the sidecar cannot
+# recover from on its own and which surfaces only as ClusterSecretStore InvalidProviderConfig.
+#
 # dependsOn the netbird-operator bundle so the SidecarProfile/SetupKey CRDs + the mutating
 # webhook + the setupkey controller exist before these resources apply (otherwise the webhook
 # denies the pod, or the CRs have no CRD, or the setup key is never minted).

--- a/apps/network/src/eso-sidecar/serviceaccount-eso-sidecar-watchdog.yaml
+++ b/apps/network/src/eso-sidecar/serviceaccount-eso-sidecar-watchdog.yaml
@@ -1,0 +1,48 @@
+# RBAC for the ESO netbird-sidecar self-heal watchdog (cronjob-eso-sidecar-watchdog.yaml).
+#
+# The external-secrets controller reaches the secret cluster's OpenBao through an injected
+# netbird native-sidecar (init container `netbird`, restartPolicy: Always) that enrolls with
+# the SetupKey in this bundle. That sidecar authenticates ONCE at pod start; when NetBird
+# management later forces a re-auth — after the host VM suspends/resumes, or a login expiry —
+# it wedges in SessionExpired/NeedsLogin and the ClusterSecretStore `openbao` goes
+# InvalidProviderConfig (every OpenBao-backed ExternalSecret then SecretSyncedError). Nothing
+# recovers it on its own, so the watchdog needs to observe the sidecar (pods/exec) and recycle
+# the controller pod (patch the Deployment). Namespaced to `external-secrets`.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netbird-eso-sidecar-watchdog
+  namespace: external-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: netbird-eso-sidecar-watchdog
+  namespace: external-secrets
+rules:
+  # Find and exec into the external-secrets pod's netbird sidecar to run `netbird status`.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [pods/exec]
+    verbs: [create]
+  # Recycle the controller via `kubectl rollout restart` (patches the pod template), which
+  # re-injects the sidecar and re-enrolls it with the SetupKey.
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: netbird-eso-sidecar-watchdog
+  namespace: external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: netbird-eso-sidecar-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: netbird-eso-sidecar-watchdog
+    namespace: external-secrets

--- a/apps/network/src/netbird-config/cronjob-router-watchdog.yaml
+++ b/apps/network/src/netbird-config/cronjob-router-watchdog.yaml
@@ -1,0 +1,92 @@
+# Self-heal watchdog for the NBRoutingPeer (deploy/router).
+#
+# WHY: the routing peer's netbird daemon logs in only at container start (`netbird up`
+# with the operator's reusable setup key). If management forces a re-auth later — a host
+# VM suspend/resume, or a login expiry — the daemon drops to NeedsLogin/SessionExpired and
+# never re-auths on its own. The NBRoutingPeer CR keeps reporting Ready and the CRD exposes
+# no probe (netbirdio/kubernetes-operator#85), so cross-cluster routing silently dies until
+# someone runs `kubectl rollout restart deploy/router` by hand.
+#
+# WHAT: every 5 min, exec `netbird status` in the router pod. `netbird status` exits 0 even
+# when the session is dead, so the decision is made on the OUTPUT. On a terminal bad state
+# we rollout-restart the Deployment; the new pod re-registers with the same reusable key
+# still in the `router` Secret. If exec fails (pod rolling / not ready) we skip the cycle so
+# we never race an in-flight restart.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: netbird-router-watchdog
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: watchdog
+              # alpine/kubectl (not registry.k8s.io/kubectl, which is distroless with no
+              # shell) — the watchdog logic runs in /bin/sh. Multi-arch, ~22MB, matches the
+              # v1.35.0 clusters. Pinned to the multi-arch index digest.
+              image: alpine/kubectl:1.35.0@sha256:862d86046bbcad03c252bbc10ab8bf893e7aa50aa7a20de8bfc46727dd645883
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  ns=netbird
+                  dep=router
+
+                  # netbird status exits 0 even when the session is dead, so decide on the
+                  # output. A non-zero exec means the pod is rolling / not ready — skip.
+                  if ! status="$(kubectl -n "$ns" exec "deploy/$dep" -c netbird -- netbird status 2>&1)"; then
+                    echo "watchdog: cannot reach deploy/$dep (rolling / not ready); skipping this cycle"
+                    printf '%s\n' "$status"
+                    exit 0
+                  fi
+                  printf '%s\n' "$status"
+
+                  # Terminal states the daemon cannot recover from without re-running
+                  # `netbird up` (which only happens at container start) -> recycle the pod.
+                  if printf '%s' "$status" | grep -qE 'Daemon status: (NeedsLogin|SessionExpired|LoginFailed)'; then
+                    echo "watchdog: deploy/$dep session is dead -> kubectl rollout restart deploy/$dep"
+                    kubectl -n "$ns" rollout restart "deploy/$dep"
+                  else
+                    echo "watchdog: deploy/$dep session healthy"
+                  fi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/network/src/netbird-config/fleet.yaml
+++ b/apps/network/src/netbird-config/fleet.yaml
@@ -4,6 +4,10 @@
 #     touch shared policy or other peers like PiKVM).
 #   - setupkey-network-k8s.yaml: a reusable SetupKey auto-joining `network-k8s`, used to
 #     enroll this cluster's routing peer(s).
+#   - serviceaccount-router-watchdog.yaml + cronjob-router-watchdog.yaml: a self-heal
+#     watchdog that recycles the NBRoutingPeer (deploy/router) when its netbird daemon
+#     wedges in NeedsLogin/SessionExpired (e.g. after a host VM suspend/resume), which the
+#     daemon cannot recover from on its own and the CR does not surface.
 # The ClusterProxy (clusterproxy-api-network.yaml) fronts the kube-apiserver over the mesh
 # with per-caller impersonation, consumed via `netbird kubernetes write-kubeconfig` — no
 # custom domain (NetBird ClusterProxy does not support api.network.vgijssel.nl yet).

--- a/apps/network/src/netbird-config/serviceaccount-router-watchdog.yaml
+++ b/apps/network/src/netbird-config/serviceaccount-router-watchdog.yaml
@@ -1,0 +1,48 @@
+# RBAC for the routing-peer self-heal watchdog (cronjob-router-watchdog.yaml).
+#
+# The NBRoutingPeer daemon authenticates ONCE at container start via `netbird up
+# --setup-key` (the operator-minted reusable key in the `router` Secret). When NetBird
+# management later forces a re-auth — after the host VM suspends/resumes, or a login
+# expiry — the running daemon has no way to feed the key back to itself and wedges in
+# NeedsLogin/SessionExpired. The NBRoutingPeer CR still reports Ready and there is no
+# liveness probe (netbirdio/kubernetes-operator#85), so nothing recycles it. The watchdog
+# needs just enough to observe the daemon (pods/exec) and recycle it (patch the
+# Deployment, i.e. `kubectl rollout restart`). Namespaced to `netbird` — it never touches
+# anything outside this namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+rules:
+  # Find and exec into the router pod to run `netbird status`.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [pods/exec]
+    verbs: [create]
+  # Recycle the routing peer via `kubectl rollout restart` (patches the pod template).
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: netbird-router-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: netbird-router-watchdog
+    namespace: netbird

--- a/apps/secret/src/netbird-config/cronjob-router-watchdog.yaml
+++ b/apps/secret/src/netbird-config/cronjob-router-watchdog.yaml
@@ -1,0 +1,92 @@
+# Self-heal watchdog for the NBRoutingPeer (deploy/router).
+#
+# WHY: the routing peer's netbird daemon logs in only at container start (`netbird up`
+# with the operator's reusable setup key). If management forces a re-auth later — a host
+# VM suspend/resume, or a login expiry — the daemon drops to NeedsLogin/SessionExpired and
+# never re-auths on its own. The NBRoutingPeer CR keeps reporting Ready and the CRD exposes
+# no probe (netbirdio/kubernetes-operator#85), so cross-cluster routing silently dies until
+# someone runs `kubectl rollout restart deploy/router` by hand.
+#
+# WHAT: every 5 min, exec `netbird status` in the router pod. `netbird status` exits 0 even
+# when the session is dead, so the decision is made on the OUTPUT. On a terminal bad state
+# we rollout-restart the Deployment; the new pod re-registers with the same reusable key
+# still in the `router` Secret. If exec fails (pod rolling / not ready) we skip the cycle so
+# we never race an in-flight restart.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: netbird-router-watchdog
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: watchdog
+              # alpine/kubectl (not registry.k8s.io/kubectl, which is distroless with no
+              # shell) — the watchdog logic runs in /bin/sh. Multi-arch, ~22MB, matches the
+              # v1.35.0 clusters. Pinned to the multi-arch index digest.
+              image: alpine/kubectl:1.35.0@sha256:862d86046bbcad03c252bbc10ab8bf893e7aa50aa7a20de8bfc46727dd645883
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  ns=netbird
+                  dep=router
+
+                  # netbird status exits 0 even when the session is dead, so decide on the
+                  # output. A non-zero exec means the pod is rolling / not ready — skip.
+                  if ! status="$(kubectl -n "$ns" exec "deploy/$dep" -c netbird -- netbird status 2>&1)"; then
+                    echo "watchdog: cannot reach deploy/$dep (rolling / not ready); skipping this cycle"
+                    printf '%s\n' "$status"
+                    exit 0
+                  fi
+                  printf '%s\n' "$status"
+
+                  # Terminal states the daemon cannot recover from without re-running
+                  # `netbird up` (which only happens at container start) -> recycle the pod.
+                  if printf '%s' "$status" | grep -qE 'Daemon status: (NeedsLogin|SessionExpired|LoginFailed)'; then
+                    echo "watchdog: deploy/$dep session is dead -> kubectl rollout restart deploy/$dep"
+                    kubectl -n "$ns" rollout restart "deploy/$dep"
+                  else
+                    echo "watchdog: deploy/$dep session healthy"
+                  fi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/secret/src/netbird-config/fleet.yaml
+++ b/apps/secret/src/netbird-config/fleet.yaml
@@ -9,6 +9,10 @@
 #     policy or other peers like PiKVM).
 #   - setupkey-secret-k8s.yaml  : a reusable SetupKey auto-joining `secret-k8s`, used to
 #     enroll this cluster's ClusterProxy proxy peer(s).
+#   - serviceaccount-router-watchdog.yaml + cronjob-router-watchdog.yaml: a self-heal
+#     watchdog that recycles the NBRoutingPeer (deploy/router) when its netbird daemon
+#     wedges in NeedsLogin/SessionExpired (e.g. after a host VM suspend/resume), which the
+#     daemon cannot recover from on its own and the CR does not surface.
 # The ClusterProxy (clusterproxy-api-secret.yaml) fronts the kube-apiserver over the mesh
 # with per-caller impersonation (serviceaccount-clusterproxy.yaml), consumed via `netbird
 # kubernetes write-kubeconfig` — no custom domain (NetBird ClusterProxy does not support

--- a/apps/secret/src/netbird-config/serviceaccount-router-watchdog.yaml
+++ b/apps/secret/src/netbird-config/serviceaccount-router-watchdog.yaml
@@ -1,0 +1,48 @@
+# RBAC for the routing-peer self-heal watchdog (cronjob-router-watchdog.yaml).
+#
+# The NBRoutingPeer daemon authenticates ONCE at container start via `netbird up
+# --setup-key` (the operator-minted reusable key in the `router` Secret). When NetBird
+# management later forces a re-auth — after the host VM suspends/resumes, or a login
+# expiry — the running daemon has no way to feed the key back to itself and wedges in
+# NeedsLogin/SessionExpired. The NBRoutingPeer CR still reports Ready and there is no
+# liveness probe (netbirdio/kubernetes-operator#85), so nothing recycles it. The watchdog
+# needs just enough to observe the daemon (pods/exec) and recycle it (patch the
+# Deployment, i.e. `kubectl rollout restart`). Namespaced to `netbird` — it never touches
+# anything outside this namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+rules:
+  # Find and exec into the router pod to run `netbird status`.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [pods/exec]
+    verbs: [create]
+  # Recycle the routing peer via `kubectl rollout restart` (patches the pod template).
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: netbird-router-watchdog
+  namespace: netbird
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: netbird-router-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: netbird-router-watchdog
+    namespace: netbird

--- a/apps/secret/src/netbird-reverse-proxy/templates/cronjob-watchdog.yaml
+++ b/apps/secret/src/netbird-reverse-proxy/templates/cronjob-watchdog.yaml
@@ -1,0 +1,95 @@
+# Self-heal watchdog for the BYOP reverse proxy (deploy/netbird-reverse-proxy).
+#
+# WHY: the proxy embeds a netbird peer that logs in only at container start (proxy token). If
+# management forces a re-auth later — a host VM suspend/resume, or a login expiry — the embedded
+# client wedges and its peer can be fully deregistered ("peer is not registered"). The pod stays
+# Running and the process keeps serving :8080/:8443, so nothing k8s-native notices, but OpenBao
+# is no longer reachable at openbao.secret.vgijssel.nl over the mesh until someone runs
+# `kubectl rollout restart deploy/netbird-reverse-proxy` by hand.
+#
+# WHAT: every 5 min, read the proxy's own health endpoint (:8080 /healthz, exposed via
+# NB_PROXY_HEALTH_ADDRESS). Its top-level "status" stays "ok" even when the mesh client is dead,
+# so the decision keys on `"all_clients_healthy":false` (the per-client checks report
+# management_connected:false / signal_connected:false in that state). On that we rollout-restart
+# the proxy; the new pod re-enrols. The container ships no curl/netbird CLI, so we use its
+# bundled busybox wget. If exec fails (pod rolling / not ready) we skip the cycle so we never
+# race an in-flight restart. Sibling of the router/eso-sidecar watchdogs.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netbird-reverse-proxy-watchdog
+  namespace: netbird
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: netbird-reverse-proxy-watchdog
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: watchdog
+              # alpine/kubectl (not registry.k8s.io/kubectl, which is distroless with no
+              # shell) — the watchdog logic runs in /bin/sh. Multi-arch, ~22MB. Pinned to the
+              # multi-arch index digest.
+              image: alpine/kubectl:1.35.0@sha256:862d86046bbcad03c252bbc10ab8bf893e7aa50aa7a20de8bfc46727dd645883
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  ns=netbird
+                  dep=netbird-reverse-proxy
+
+                  # Read the proxy's own /healthz via its bundled busybox wget (no curl/netbird
+                  # CLI in the image). A non-zero exec means the pod is rolling / not ready — skip.
+                  if ! health="$(kubectl -n "$ns" exec "deploy/$dep" -c netbird-reverse-proxy -- /busybox/wget -q -T 5 -O - http://127.0.0.1:8080/healthz 2>&1)"; then
+                    echo "watchdog: cannot reach $dep /healthz (rolling / not ready); skipping this cycle"
+                    printf '%s\n' "$health"
+                    exit 0
+                  fi
+                  printf '%s\n' "$health"
+
+                  # Top-level "status" is "ok" even when the embedded mesh client is dead; the
+                  # authoritative signal is all_clients_healthy. false -> the peer is wedged /
+                  # deregistered and only re-enrols at container start, so recycle the pod.
+                  if printf '%s' "$health" | grep -q '"all_clients_healthy":false'; then
+                    echo "watchdog: $dep mesh client unhealthy -> kubectl rollout restart deploy/$dep"
+                    kubectl -n "$ns" rollout restart "deploy/$dep"
+                  else
+                    echo "watchdog: $dep mesh client healthy"
+                  fi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/secret/src/netbird-reverse-proxy/templates/serviceaccount-watchdog.yaml
+++ b/apps/secret/src/netbird-reverse-proxy/templates/serviceaccount-watchdog.yaml
@@ -1,0 +1,47 @@
+# RBAC for the reverse-proxy self-heal watchdog (cronjob-watchdog.yaml).
+#
+# The BYOP reverse proxy embeds a netbird peer that authenticates ONCE at container start (the
+# proxy token). When NetBird management later forces a re-auth — after the host VM
+# suspends/resumes, or a login expiry — the embedded client wedges (its peer can even be
+# deregistered: "peer is not registered") and OpenBao stops being reachable at
+# openbao.secret.vgijssel.nl over the mesh. Nothing recovers it on its own, so the watchdog
+# needs to read the proxy's /healthz (pods/exec) and recycle it (patch the Deployment).
+# Namespaced to `netbird`.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netbird-reverse-proxy-watchdog
+  namespace: netbird
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: netbird-reverse-proxy-watchdog
+  namespace: netbird
+rules:
+  # Find and exec into the reverse-proxy pod to read its :8080 /healthz endpoint.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [pods/exec]
+    verbs: [create]
+  # Recycle the proxy via `kubectl rollout restart` (patches the pod template), which
+  # re-enrols the embedded netbird peer.
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: netbird-reverse-proxy-watchdog
+  namespace: netbird
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: netbird-reverse-proxy-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: netbird-reverse-proxy-watchdog
+    namespace: netbird


### PR DESCRIPTION
## Problem

After an OrbStack VM suspend/resume (Mac sleep), **every long-lived NetBird client peer** across both clusters wedged, silently killing cross-cluster connectivity. Each peer authenticates only at container start; when NetBird management later forces a re-auth (suspend/resume, or a 24h login expiry) the running daemon can't re-auth itself. The Kubernetes objects still look healthy and there is no probe ([netbirdio/kubernetes-operator#85](https://github.com/netbirdio/kubernetes-operator/issues/85)), so nothing recycles them.

Affected peers (all confirmed broken live via the NetBird management API — the eso-sidecar and reverse-proxy peers were fully **deregistered**, `peer is not registered`):

| Peer | Cluster | Impact when wedged |
|------|---------|--------------------|
| `deploy/router` (NBRoutingPeer) | network + secret | cross-cluster routes vanish (Omada, JWKS) |
| `deploy/external-secrets` netbird sidecar | network | `openbao` ClusterSecretStore `InvalidProviderConfig`, all OpenBao-backed ExternalSecrets `SecretSyncedError` |
| `deploy/netbird-reverse-proxy` | secret | OpenBao unreachable at `openbao.secret.vgijssel.nl` over the mesh |

## Fix — a self-heal watchdog per peer

Each is a CronJob (*/5 min) + dedicated ServiceAccount/Role/RoleBinding (namespaced; `pods` get/list, `pods/exec` create, `deployments` get/patch), added to the peer's own bundle:

- **router** → `apps/{network,secret}/src/netbird-config/` — exec `netbird status`, restart `deploy/router` on a terminal bad state.
- **eso-sidecar** → `apps/network/src/eso-sidecar/` — exec `netbird status` in the sidecar, restart `deploy/external-secrets`.
- **reverse-proxy** → `apps/secret/src/netbird-reverse-proxy/` (Helm chart) — the image ships no netbird/curl CLI, so it reads the proxy's own `:8080/healthz` via bundled busybox wget and keys on `"all_clients_healthy":false`.

### Design notes (from live debugging)
- Detection is **output-based** — `netbird status` exits `0` even when dead, and the reverse-proxy `/healthz` returns top-level `status:ok` even when its mesh client is dead (real signal is `all_clients_healthy`).
- `alpine/kubectl:1.35.0` (pinned by index digest) because `registry.k8s.io/kubectl` and `rancher/kubectl` are **distroless (no `/bin/sh`)** and the logic runs in a shell.
- Skips the cycle on exec failure (pod rolling) + `concurrencyPolicy: Forbid` → never races an in-flight restart.
- Hardened: non-root, read-only rootfs, caps dropped, small resource limits.

## Verification

Deployed and tested end-to-end on both live clusters. For each of the three watchdogs:
1. **Fault path** — detected the wedged/deregistered peer → `rollout restart` → job `Complete`.
2. **Recovery** — router `Management: Connected`; eso sidecar `Management/Signal: Connected` with `openbao` store back to `Valid` and all ExternalSecrets `SecretSynced`; reverse-proxy `/healthz` `all_clients_healthy: true`.
3. **Healthy path** — re-run against the recovered peer reports `healthy`, no restart.

## Follow-ups (not in this PR)
- Deeper fix: disable peer login-expiration for these groups upstream so re-auth isn't forced at all (operator/CRD exposes no knob; would be an out-of-band NetBird account change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)