### PR TITLE
feat(omada): back up native Auto Backup .cfg files off-cluster to Hetzner S3

### DIFF
--- a/apps/network/src/omada/templates/cronjob-omada-backup.yaml
+++ b/apps/network/src/omada/templates/cronjob-omada-backup.yaml
@@ -1,0 +1,181 @@
+# Ship Omada's native Auto Backup .cfg files off-cluster to S3-compatible object storage.
+#
+# WHY: Omada's own Auto Backup engine writes rotated, encrypted .cfg snapshots to
+# /opt/tplink/EAPController/data/autobackup on the data PVC — but that PVC lives on the same
+# OrbStack VM disk as everything else, so a disk/machine loss takes the backups with it. The
+# .cfg is a portable LOGICAL backup (architecture-/host-independent), which is exactly the
+# artifact to restore into the future amd64 cluster; getting it off the box is the whole point.
+#
+# WHAT: daily, an init step (alpine/kubectl) finds the running Omada pod by label and streams
+# the autobackup dir out via `kubectl exec ... -- tar` into a shared emptyDir; then rclone
+# uploads it with `copy` (additive — never deletes) so S3 accumulates full history even after
+# Omada rotates the local copies. rclone's remote `s3:` is configured entirely from env
+# (RCLONE_CONFIG_S3_*), with the access/secret keys coming from the ESO-synced
+# omada-backup-s3 Secret (externalsecret-omada-backup-s3.yaml).
+#
+# PREREQUISITE (one-time, manual): enable Omada Auto Backup in the UI —
+#   Settings > Backup & Restore > Auto Backup: Daily, pick a retained-data range (NOT
+#   "Settings only" if you want client/stats history), set a max file count. Until at least one
+#   .cfg exists the job logs "no .cfg files yet" and exits cleanly.
+#
+# NOTE: assumes the S3 endpoint is reachable over normal internet egress (AWS/B2/public MinIO).
+# If your endpoint is only reachable over the NetBird mesh, add a netbird client sidecar like
+# apps/network/src/eso-sidecar does for OpenBao.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: omada-backup
+  namespace: omada
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  timeZone: {{ .Values.backup.timeZone | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: omada-backup
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            # Copy the autobackup .cfg files out of the running Omada container into /work.
+            # alpine/kubectl (not registry.k8s.io/kubectl, which is distroless with no shell) —
+            # the logic runs in /bin/sh, and busybox tar unpacks the stream. Pinned to the
+            # multi-arch index digest, matching the v1.35.0 clusters.
+            - name: fetch-cfg
+              image: alpine/kubectl:1.35.0@sha256:862d86046bbcad03c252bbc10ab8bf893e7aa50aa7a20de8bfc46727dd645883
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests: { cpu: 10m, memory: 32Mi }
+                limits: { cpu: 200m, memory: 128Mi }
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: work
+                  mountPath: /work
+              command: [/bin/sh, -c]
+              args:
+                - |
+                  set -eu
+                  ns=omada
+                  sel='app.kubernetes.io/name=omada-controller,app.kubernetes.io/instance=omada'
+                  # First Running pod matching the selector (StatefulSet is single-replica).
+                  pod="$(kubectl -n "$ns" get pod -l "$sel" \
+                    -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null \
+                    | awk '{print $1}')"
+                  if [ -z "$pod" ]; then
+                    echo "omada-backup: no Running omada pod (selector $sel); nothing to fetch"
+                    exit 0
+                  fi
+                  echo "omada-backup: source pod $pod"
+
+                  dir=/opt/tplink/EAPController/data/autobackup
+                  if ! kubectl -n "$ns" exec "$pod" -c omada-controller -- \
+                        sh -c "ls $dir/*.cfg >/dev/null 2>&1"; then
+                    echo "omada-backup: no .cfg files under $dir yet."
+                    echo "  -> enable Omada Auto Backup: Settings > Backup & Restore > Auto Backup."
+                    exit 0
+                  fi
+
+                  mkdir -p /work/autobackup
+                  # No TTY (-i/-t) so the tar stream stays binary-clean.
+                  kubectl -n "$ns" exec "$pod" -c omada-controller -- \
+                    tar cf - -C /opt/tplink/EAPController/data autobackup | tar xf - -C /work
+                  n="$(ls -1 /work/autobackup/*.cfg 2>/dev/null | wc -l | tr -d ' ')"
+                  echo "omada-backup: fetched ${n} .cfg file(s)"
+          containers:
+            # Upload the fetched .cfg files to S3-compatible storage. rclone/rclone is alpine-based
+            # (has /bin/sh); the `s3:` remote is built from RCLONE_CONFIG_S3_* env. Pinned to the
+            # multi-arch (arm64+amd64) index digest.
+            - name: upload
+              image: rclone/rclone:1.71.1@sha256:d5971950c2b370fb04dd3292541b5bda6d9103143fd7e345aeb435a399388afc
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: RCLONE_CONFIG_S3_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_S3_PROVIDER
+                  value: {{ .Values.backup.s3.provider | quote }}
+                - name: RCLONE_CONFIG_S3_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: omada-backup-s3
+                      key: endpoint
+                - name: RCLONE_CONFIG_S3_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: omada-backup-s3
+                      key: region
+                - name: RCLONE_CONFIG_S3_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: omada-backup-s3
+                      key: access_key_id
+                - name: RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: omada-backup-s3
+                      key: secret_access_key
+                - name: BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: omada-backup-s3
+                      key: bucket
+                - name: PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests: { cpu: 10m, memory: 32Mi }
+                limits: { cpu: 200m, memory: 128Mi }
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: work
+                  mountPath: /work
+              command: [/bin/sh, -c]
+              args:
+                - |
+                  set -eu
+                  src=/work/autobackup
+                  if [ ! -d "$src" ] || ! ls "$src"/*.cfg >/dev/null 2>&1; then
+                    echo "omada-backup: nothing to upload"
+                    exit 0
+                  fi
+                  if [ -z "${BUCKET}" ]; then
+                    echo "omada-backup: bucket is empty — set the 'bucket' field in kv/s3-backup" >&2
+                    exit 1
+                  fi
+                  n="$(ls -1 "$src"/*.cfg | wc -l | tr -d ' ')"
+                  dest="s3:${BUCKET}/${PREFIX}"
+                  echo "omada-backup: uploading ${n} .cfg file(s) to ${dest}"
+                  # copy (not sync): additive, never deletes — S3 keeps history beyond Omada's
+                  # local rotation. --s3-no-check-bucket avoids needing CreateBucket permission.
+                  rclone copy "$src" "$dest" --s3-no-check-bucket --stats-one-line -v
+                  echo "omada-backup: upload complete"
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: work
+              emptyDir: {}

--- a/apps/network/src/omada/templates/externalsecret-omada-backup-s3.yaml
+++ b/apps/network/src/omada/templates/externalsecret-omada-backup-s3.yaml
@@ -1,0 +1,49 @@
+# Materializes the shared Hetzner S3 backup credentials for the Omada .cfg backup CronJob
+# (cronjob-omada-backup.yaml), synced from OpenBao via the shared `openbao` ClusterSecretStore
+# (JWT auth over the NetBird mesh — see apps/network/src/config/clustersecretstore-openbao.yaml).
+# The kv/s3-backup key is generic/reusable across backup jobs; rclone reads it as the
+# RCLONE_CONFIG_S3_ACCESS_KEY_ID / _SECRET_ACCESS_KEY env vars, so the keys never appear in a
+# manifest or in values.yaml. Stays NotReady until OpenBao has kv/<backup.openbao.key>; Fleet
+# retries, which is expected during bootstrap.
+#
+# Populate OpenBao once (from a host that can reach it), e.g.:
+#   bao kv put kv/{{ .Values.backup.openbao.key }} \
+#     {{ .Values.backup.openbao.accessKeyProperty }}=<S3_ACCESS_KEY_ID> \
+#     {{ .Values.backup.openbao.secretKeyProperty }}=<S3_SECRET_ACCESS_KEY> \
+#     {{ .Values.backup.openbao.regionProperty }}=<S3_REGION> \
+#     {{ .Values.backup.openbao.bucketProperty }}=<S3_BUCKET> \
+#     {{ .Values.backup.openbao.endpointProperty }}=<S3_ENDPOINT>
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: omada-backup-s3
+  namespace: omada
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: omada-backup-s3
+    creationPolicy: Owner
+  data:
+    - secretKey: access_key_id
+      remoteRef:
+        key: {{ .Values.backup.openbao.key | quote }}
+        property: {{ .Values.backup.openbao.accessKeyProperty | quote }}
+    - secretKey: secret_access_key
+      remoteRef:
+        key: {{ .Values.backup.openbao.key | quote }}
+        property: {{ .Values.backup.openbao.secretKeyProperty | quote }}
+    - secretKey: region
+      remoteRef:
+        key: {{ .Values.backup.openbao.key | quote }}
+        property: {{ .Values.backup.openbao.regionProperty | quote }}
+    - secretKey: bucket
+      remoteRef:
+        key: {{ .Values.backup.openbao.key | quote }}
+        property: {{ .Values.backup.openbao.bucketProperty | quote }}
+    - secretKey: endpoint
+      remoteRef:
+        key: {{ .Values.backup.openbao.key | quote }}
+        property: {{ .Values.backup.openbao.endpointProperty | quote }}

--- a/apps/network/src/omada/templates/serviceaccount-omada-backup.yaml
+++ b/apps/network/src/omada/templates/serviceaccount-omada-backup.yaml
@@ -1,0 +1,38 @@
+# RBAC for the Omada .cfg backup job (cronjob-omada-backup.yaml). The job locates the running
+# Omada pod by label and streams the autobackup .cfg files out with `kubectl exec ... -- tar`,
+# so it needs exactly: read pods (find the pod) and create pods/exec (run tar in it). It never
+# writes to the cluster and never touches anything outside the `omada` namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: omada-backup
+  namespace: omada
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: omada-backup
+  namespace: omada
+rules:
+  # Find the Omada pod by selector.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  # `kubectl exec ... -- tar cf -` to read the autobackup dir out of the running container.
+  - apiGroups: [""]
+    resources: [pods/exec]
+    verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: omada-backup
+  namespace: omada
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: omada-backup
+subjects:
+  - kind: ServiceAccount
+    name: omada-backup
+    namespace: omada

--- a/apps/network/src/omada/values.yaml
+++ b/apps/network/src/omada/values.yaml
@@ -38,3 +38,32 @@ omada-controller-helm:
     logs:
       enabled: true
       size: 1Gi
+
+# Off-machine backup of Omada's NATIVE Auto Backup .cfg files (templates/cronjob-omada-backup.yaml).
+# Omada's own Auto Backup engine (enable ONCE in the UI: Settings > Backup & Restore > Auto Backup)
+# writes rotated, encrypted .cfg snapshots to /opt/tplink/EAPController/data/autobackup on the data
+# PVC. The CronJob copies those .cfg files out of the running pod (kubectl exec | tar) and uploads
+# them to S3-compatible object storage with rclone (additive `copy`, so S3 keeps full history even
+# after Omada rotates the local copies). The .cfg is a portable logical backup — architecture- and
+# host-independent — so it is the safe artifact for the planned arm64 -> amd64 cluster move.
+#
+# Credentials come from OpenBao (kv/<openbao.key>) via ESO (templates/externalsecret-omada-backup-s3.yaml,
+# the shared `openbao` ClusterSecretStore). Endpoint/bucket/region are NOT secret and live here.
+backup:
+  # Daily at 03:17 Amsterdam — after Omada's own nightly auto-backup has written the day's .cfg.
+  schedule: 17 3 * * *
+  timeZone: Europe/Amsterdam
+  # Hetzner Object Storage (S3-compatible), rclone `s3` backend with the generic `Other` provider.
+  s3:
+    provider: Other
+    prefix: omada # the omada directory within the bucket -> objects at <bucket>/omada/<file>.cfg
+  # Shared/generic S3 backup target in OpenBao (kv/s3-backup), reusable across jobs: the creds,
+  # region, bucket AND endpoint all travel as one secret. Only the omada-specific prefix (and the
+  # rclone provider hint) live here.
+  openbao:
+    key: s3-backup
+    accessKeyProperty: access_key_id
+    secretKeyProperty: secret_access_key
+    regionProperty: region
+    bucketProperty: bucket
+    endpointProperty: endpoint


### PR DESCRIPTION
## What

Adds a daily Kubernetes CronJob to the `omada` umbrella chart that ships Omada's **native** Auto Backup `.cfg` files off-cluster to Hetzner Object Storage (S3-compatible).

## Why

Omada's own Auto Backup writes rotated, encrypted `.cfg` snapshots to `/opt/tplink/EAPController/data/autobackup` on the data PVC — but that PVC lives on the same OrbStack VM disk as everything else, so a disk/machine loss takes the backups with it. The `.cfg` is a portable **logical** backup (architecture-/host-independent), which is exactly the artifact to restore into the future **amd64** cluster — getting it off the box is the whole point.

Design decision: use Omada's own tested backup engine as the producer (no brittle API/CSRF/login), and let the job only *ship* the files.

## How

- **init step** (`alpine/kubectl`) finds the running Omada pod by label and streams the autobackup dir out via `kubectl exec … -- tar` into a shared `emptyDir`.
- **`rclone copy`** (additive — never deletes) uploads to `s3:<bucket>/omada/`, so S3 keeps full history even after Omada rotates its local copies.
- The **entire S3 target** (access key, secret key, region, bucket, endpoint) travels as one reusable OpenBao secret `kv/s3-backup`, synced via ESO through the shared `openbao` ClusterSecretStore. Only the omada-specific `prefix` + rclone `provider` hint live in `values.yaml`.
- Minimal RBAC (`pods` get/list, `pods/exec` create), hardened pod (non-root 65532, read-only rootfs, seccomp `RuntimeDefault`, all caps dropped), images pinned to multi-arch (arm64+amd64) digests so it survives the arm64→amd64 move unchanged.

## Validation (live on the network cluster)

- ESO `omada-backup-s3` → `SecretSynced / Ready=True`
- S3 auth + egress to Hetzner `nbg1` OK, bucket `enigma-s3-backup` reachable
- Real backup end-to-end: `autobackup_6.2.14.11_30days_2026-07-30_….cfg` (194 KiB) fetched from the pod and uploaded to `s3:enigma-s3-backup/omada/`, confirmed present

## Operator prerequisites

1. Populate OpenBao once:
   ```
   bao kv put kv/s3-backup access_key_id=… secret_access_key=… region=nbg1 bucket=enigma-s3-backup endpoint=nbg1.your-objectstorage.com
   ```
2. Enable Omada Auto Backup in the UI (*Settings → Backup & Restore → Auto Backup*) — the source of the `.cfg` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)