### PR TITLE
feat(pikvm): trunk eth0 (DHCP untagged + static VLAN 10) & make apply-over-NetBird work

### DIFF
--- a/apps/network/network.md
+++ b/apps/network/network.md
@@ -1,0 +1,130 @@
+# Home Network (Omada) — Configuration Reference
+
+Reference for the physical home LAN managed by TP-Link Omada (gateway + switch + APs).
+This is the **target configuration** the Omada controller should hold. The controller
+software itself runs in the `network` vind cluster (`apps/network/src/omada`) and is
+reached over the NetBird mesh; the PiKVM (`apps/pikvm`) is the site-to-VPN ingress that
+lets LAN devices and the Omada hardware reach that controller.
+
+> Status (2026-07-30): **gateway not yet installed.** The ISP modem currently does DHCP on
+> a flat `192.168.1.0/24`. The PiKVM's `eth0` is **DHCP** so it follows whichever VLAN its
+> access port lives in during the modem→Omada cutover. See "Migration / cutover" below.
+
+## Topology
+
+```
+Internet ── ISP modem (bridge mode) ── Omada Gateway (router, DHCP, firewall)
+                                             │
+                                        Omada Switch ── APs
+                                             │
+                    ┌────────────────────────┼────────────────────────┐
+                  VLANs 10/20/30/40/50/90 (see table)
+                                             │
+                              PiKVM (NetBird routing peer, wt0)
+                                             │
+                                      NetBird mesh
+                                             │
+                        Omada Controller @ 10.96.0.20 (network cluster)
+```
+
+- LAN clients use the **Omada gateway as their default gateway**. To reach the Omada
+  controller they send to `10.96.0.20`, the gateway's static route forwards to the PiKVM,
+  and the PiKVM routes it into the NetBird mesh (SNAT/masquerade on `wt0`).
+- The Omada **hardware** (gateway/switch/APs) is adopted by the remote controller the same
+  way — it needs the `10.96.0.20/32 → PiKVM` static route to be reachable.
+
+## Addressing rules
+
+- Scheme: **`192.168.<vlan>.0/24`** — chosen to be visually distinct from Kubernetes ranges.
+- The gateway interface (SVI) for each VLAN is **`.1`**.
+- **Never** use a LAN subnet inside the cluster CIDRs, or the controller path silently breaks:
+  - Service CIDR `10.96.0.0/16` (holds the Omada ClusterIP `10.96.0.20`)
+  - Pod CIDR `10.244.0.0/16`
+- NetBird advertises only the host route `10.96.0.20/32` into the mesh (not whole subnets).
+
+## VLANs
+
+| VLAN | Name | Subnet | Gateway | Purpose / devices | Internet | Inter-VLAN |
+|-----:|------|--------|---------|-------------------|:--------:|------------|
+| 10 | Management | `192.168.10.0/24` | `.1` | Omada gateway/switch/APs, **PiKVM** | restricted | admin plane; reachable only from Trusted |
+| 20 | Servers | `192.168.20.0/24` | `.1` | servers, **Home Assistant (HAOS)** | yes | HAOS ↔ IoT allowed (see DNS/mDNS) |
+| 30 | Trusted | `192.168.30.0/24` | `.1` | laptops, phones | yes | may initiate to all VLANs |
+| 40 | IoT | `192.168.40.0/24` | `.1` | esphome, dishwasher, washing machine, car charger | per-device | no LAN-init; accept only from Trusted/HAOS |
+| 50 | Media | `192.168.50.0/24` | `.1` | TVs | yes | no LAN-init to other VLANs |
+| 90 | Guest | `192.168.90.0/24` | `.1` | visitors | yes | fully isolated (internet only) |
+
+## DHCP
+
+Per VLAN, on the Omada gateway (single DHCP authority — the modem's DHCP is **off** once
+bridged; never run two DHCP servers on one L2):
+
+| VLAN | DHCP pool | Reservations (below the pool) | Lease |
+|-----:|-----------|-------------------------------|-------|
+| 10 | `.100`–`.199` | **PiKVM → reserved (by MAC)** so its LAN IP is stable | 24h |
+| 20 | `.100`–`.199` | servers, HAOS reserved by MAC | 24h |
+| 30 | `.100`–`.199` | — | 24h |
+| 40 | `.100`–`.199` | appliances reserved by MAC (for firewall rules) | 24h |
+| 50 | `.100`–`.199` | — | 24h |
+| 90 | `.100`–`.199` | — | 4h |
+
+- **PiKVM reservation is required.** `eth0` is DHCP, but the Omada static route next-hop and
+  the NetBird site-to-VPN path need a predictable address. Reserve the PiKVM's MAC to a fixed
+  address on VLAN 10 (and, during migration, on the legacy `192.168.1.0/24`).
+- DNS advertised via DHCP: the Omada gateway (`.1`), which forwards upstream.
+
+## Static routes (Omada gateway)
+
+| Destination | Next hop | Purpose |
+|-------------|----------|---------|
+| `10.96.0.20/32` | PiKVM LAN IP (VLAN 10 reservation) | reach the Omada controller in the NetBird mesh |
+| `100.65.0.0/16` | PiKVM LAN IP | (optional) reach other NetBird mesh peers from the LAN |
+
+The PiKVM masquerades LAN→mesh traffic (`setup-netbird-routing.sh`, `LAN_CIDR=192.168.0.0/16`),
+so return traffic comes back through it. The NetBird dashboard must (a) designate the PiKVM
+as a routing peer advertising `10.96.0.20/32` with Masquerade, and (b) permit the LAN source
+group → the Omada resource.
+
+## Firewall / ACL policy
+
+Default **deny** between VLANs; allow only:
+
+- Trusted (30) → all VLANs
+- Servers/HAOS (20) ↔ IoT (40): the specific ports Home Assistant needs
+- Any VLAN → the controller route (`10.96.0.20`) as needed for Omada management
+- IoT (40) / Media (50) / Guest (90) → other VLANs: **deny** (established/return + permitted internet only)
+
+## DNS / discovery
+
+- **mDNS repeater** enabled between VLANs 20 ↔ 30 ↔ 40 so Home Assistant and phones can
+  discover esphome/appliances/casting targets across the segmentation boundary.
+- Public DNS resolution via the gateway; `omada.network.vgijssel.nl` resolves publicly
+  (Cloudflare) to `10.96.0.20` and is reached over the mesh route.
+
+## Switch port profiles
+
+| Port role | Native (untagged) | Tagged | Used by |
+|-----------|-------------------|--------|---------|
+| Trunk (uplinks, APs) | Management (10) | 20/30/40/50/90 | gateway↔switch, switch↔APs |
+| PiKVM | (its access VLAN) | — | **access port**, not a trunk — see note |
+| Access | one VLAN | — | single-VLAN endpoints |
+
+> **PiKVM is an access port, not a trunk.** Because `eth0` is DHCP, the PiKVM takes the VLAN
+> of whatever access port it is plugged into. During migration that port is on the legacy
+> network; after cutover it is moved to Management (VLAN 10). No 802.1Q tagging on the PiKVM.
+
+## Migration / cutover (modem → Omada)
+
+1. Bridge the ISP modem; bring up the Omada gateway with its **initial default LAN =
+   `192.168.1.0/24`, gateway `.1`** so every existing device (incl. the PiKVM on DHCP) keeps
+   working. Modem DHCP off.
+2. Add static route `10.96.0.20/32 → PiKVM` (its current `192.168.1.x` lease); confirm the
+   PiKVM NetBird routing peer + ACL are up. Adopt gateway/switch/APs (Inform URL → controller).
+3. Create VLANs 10/20/30/40/50/90 with DHCP pools + reservations above.
+4. Migrate clients onto their VLANs incrementally. Move the PiKVM's access port to VLAN 10;
+   it re-leases into `192.168.10.x` (use its reservation). Confirm PiKVM reachable on VLAN 10.
+5. **Repoint before removing anything:** static route → `10.96.0.20/32 → <PiKVM VLAN 10 IP>`.
+   (`PIKVM_LAN_CIDR` is already `192.168.0.0/16`, so the masquerade needs no change.)
+6. With nothing left on it, delete the legacy `192.168.1.0/24` LAN.
+
+Legacy `192.168.1.0/24` must survive until step 5 is verified — adoption (step 2) is **not**
+the finish line.

--- a/apps/network/src/mongodb/perconaservermongodb.yaml
+++ b/apps/network/src/mongodb/perconaservermongodb.yaml
@@ -69,11 +69,20 @@ spec:
     image: percona/pmm-client:3.8.1
   # Custom application user for Omada. No passwordSecretRef → the operator auto-generates
   # the password (into mongodb-custom-user-secret) and the connection strings (into
-  # mongodb-custom-user-secret-conn-str). dbOwner on the `omada` database; authenticates
-  # against admin (db: admin).
+  # mongodb-custom-user-secret-conn-str). Authenticates against admin (db: admin).
+  #
+  # Omada Controller v5+ uses TWO databases, not one: `omada` (config/inventory, the db in
+  # the connection URI) AND `omada_data` (portal/radius/statistics collections such as
+  # `authrecord`). The old groundhog2k chart connected as MongoDB root, so both databases
+  # were writable implicitly; the Percona-scoped user must be granted dbOwner on BOTH or
+  # Omada crashes with `error 13 (Unauthorized): not authorized on omada_data …` the moment
+  # it touches portal/radius data. dbOwner (readWrite + dbAdmin + userAdmin) lets Omada
+  # create the database, its collections, and their indexes on first use.
   users:
     - name: omada
       db: admin
       roles:
         - name: dbOwner
           db: omada
+        - name: dbOwner
+          db: omada_data

--- a/apps/pikvm/deploy.py
+++ b/apps/pikvm/deploy.py
@@ -30,7 +30,6 @@ Behaviour reproduced verbatim from https://docs.pikvm.org/netbird/ (asset files 
 """
 
 import hashlib
-import ipaddress
 import os
 from io import StringIO
 from pathlib import Path
@@ -45,6 +44,7 @@ from pyinfra_custom.facts import (
     NetbirdDnsDisabled,
     NetbirdServerSshAllowed,
     NetbirdSshRootEnabled,
+    NetbirdSshSftpEnabled,
     NetbirdVersion,
     NetdataVersion,
     OpenBaoSecret,
@@ -162,7 +162,11 @@ _resolv_conf_sha = hashlib.sha256(_resolv_conf.encode()).hexdigest()
 
 # It is out of sync if it is still the resolved-managed symlink, or a plain file whose
 # contents differ from ours. A converged box (our static file already in place) does nothing.
-resolv_is_symlink = host.get_fact(Link, path=RESOLV_CONF_REMOTE) is not None
+# The Link fact returns a dict for a symlink, False for a non-link file, and None if absent
+# -- so a plain `is not None` wrongly treats an already-converged regular file (False) as a
+# symlink and then errors removing a link that isn't there. Only a dict means "still a
+# symlink we must drop first".
+resolv_is_symlink = isinstance(host.get_fact(Link, path=RESOLV_CONF_REMOTE), dict)
 resolv_needs_rw = (
     resolv_is_symlink
     or host.get_fact(Sha256File, path=RESOLV_CONF_REMOTE) != _resolv_conf_sha
@@ -381,7 +385,14 @@ with rootfs.writable(changed_if=netbird_needs_rw):
         )
 
 
-# ── netbird up (DNS + native SSH enabled) + config-change restart (Task 6) ───────
+# ── netbird up (DNS + native SSH + SFTP enabled) + config-change restart (Task 6) ─
+# SFTP: the native SSH server is started with `--enable-ssh-sftp` (`enable_ssh_sftp=True`)
+# so it serves an SFTP subsystem. pyinfra's `files.put` uploads over SFTP, so WITHOUT this
+# the apply cannot transfer any changed file when it runs over the NetBird SSH server --
+# it fails with "Unable to establish SFTP connection". (The netbird@ systemd override also
+# drops ProtectHome/ProtectSystem so those SSH sessions can write the rootfs at all -- see
+# files/netbird@.service.d/pikvm.conf.) Persisted as EnableSSHSFTP; reconciled below.
+#
 # NATIVE SSH: NetBird's built-in SSH server is enabled here (`allow_server_ssh=True`)
 # with root login permitted (`enable_ssh_root=True`) so the box stays reachable as
 # `root` the same way it is today, but authenticated by NetBird/IdP identity (JWT) over
@@ -427,6 +438,10 @@ dns_currently_disabled = host.get_fact(NetbirdDnsDisabled)
 # which correctly drives the reconcile to turn them on.
 ssh_server_allowed = host.get_fact(NetbirdServerSshAllowed)
 ssh_root_enabled = host.get_fact(NetbirdSshRootEnabled)
+# SFTP subsystem on the native SSH server: pyinfra's files.put uploads over SFTP, so the
+# apply cannot transfer a changed file when it runs OVER the NetBird SSH server unless this
+# is on. Persisted as EnableSSHSFTP; drives the reconcile the same way as the flags above.
+ssh_sftp_enabled = host.get_fact(NetbirdSshSftpEnabled)
 
 if not netbird_connected and SKIP_SECRETS:
     # Registration needs the setup key from OpenBao; there is no secret-free path to
@@ -452,11 +467,12 @@ if not netbird_connected:
     # netbird.up passes the setup key via per-command _env ($NB_SETUP_KEY) -- never in
     # argv or --dry.
     netbird.up(
-        name="NetBird: register with setup key (DNS + native SSH enabled)",
+        name="NetBird: register with setup key (DNS + native SSH + SFTP enabled)",
         setup_key=_secret("netbird_setup_key"),
         disable_dns=False,
         allow_server_ssh=True,
         enable_ssh_root=True,
+        enable_ssh_sftp=True,
     )
     with rootfs.writable(changed_if=True):
         server.shell(
@@ -479,7 +495,7 @@ else:
             "sleep 1; "
             "netbird down || true; "
             "netbird up --disable-dns=false "
-            "--allow-server-ssh=true --enable-ssh-root=true; "
+            "--allow-server-ssh=true --enable-ssh-root=true --enable-ssh-sftp=true; "
             "rw; cp -a /tmp/netbird-state/. /root/netbird-state/; ro"
             "'",
         ],
@@ -491,6 +507,7 @@ else:
             or dns_currently_disabled
             or not ssh_server_allowed
             or not ssh_root_enabled
+            or not ssh_sftp_enabled
         ),
     )
 
@@ -541,60 +558,92 @@ if passwords_need_update:
         )
 
 
-# ── Static IPv4 via systemd-networkd (Task 8) ────────────────────────────────────
-# Assign a static IPv4 by rendering /etc/systemd/network/<iface>.network. The default
-# address equals the current LAN IP (192.168.1.31/24), so a normal apply changes no
-# address -- only pins it. Applying it uses `networkctl reload && reconfigure`, not a
-# networkd restart, so the active SSH session is not severed when the address is
-# unchanged.
+# ── DHCP (untagged) + static VLAN 10 via systemd-networkd (Task 8) ────────────────
+# The PiKVM's switch port is a TRUNK: it carries the untagged/native VLAN plus tagged
+# 802.1Q VLAN 10 (Management). We configure both:
+#   * <iface>.network  -> DHCP=ipv4 on the untagged/native traffic (takes whatever lease
+#     the DHCP server on the native VLAN hands out) AND VLAN=vlan10 to attach the tagged
+#     device on top of the physical link. The default route comes from this DHCP lease.
+#   * vlan10.netdev    -> creates the 802.1Q tagged interface (Kind=vlan, Id=10).
+#   * vlan10.network   -> pins the tagged interface to the static Management address
+#     192.168.10.2/24 (no gateway -- untagged DHCP owns the default route). This is the
+#     stable, predictable address the Omada static route (10.96.0.20 -> pikvm) and the
+#     NetBird site-to-VPN path want as a next-hop, independent of the DHCP lease.
+# Applying it uses `networkctl reload && reconfigure`, not a networkd restart, so the
+# eth0/LAN session used by `apply_local` is not bounced.
 #
-# CONNECTIVITY RISK (SPEC "ask first"): changing PIKVM_STATIC_IP/gateway to values that
-# differ from the live network can drop the box mid-apply. Get operator sign-off before
-# the first real apply; prefer running with `-- --dry` first.
+# CONNECTIVITY: ongoing management (inventories/production.py) targets the PiKVM's
+# *NetBird* IP, not its LAN address, so a changing untagged DHCP lease does NOT affect
+# `pikvm:apply`. RECOMMENDED: still set a DHCP reservation for this box's MAC on the
+# untagged VLAN so console/local access is stable; the management path uses the static
+# 192.168.10.2 on VLAN 10 regardless.
 #
-# The template is rendered here (single source of bytes) and uploaded with files.put so
-# the rw gate's sha256 exactly matches what is written -> empty diff on a converged box.
+# CONNECTIVITY RISK (SPEC "ask first"): the first apply that changes a live interface
+# re-requests the untagged lease and re-attaches the VLAN, so the untagged LAN IP may
+# change mid-apply. Do it with a reservation in place or with console access. Prefer
+# running with `-- --dry` first.
+#
+# The eth0 template is rendered here (single source of bytes) and uploaded with files.put;
+# the two vlan10 files are static assets. All are sha256-gated so a converged box makes
+# no change and produces an empty diff.
 
-STATIC_IFACE = os.environ.get("PIKVM_NET_IFACE", "eth0")
-STATIC_IP = os.environ.get("PIKVM_STATIC_IP", "192.168.1.31")
-STATIC_PREFIX = os.environ.get("PIKVM_STATIC_PREFIX", "24")
-STATIC_GATEWAY = os.environ.get("PIKVM_GATEWAY", "192.168.1.1")
-STATIC_DNS = os.environ.get("PIKVM_DNS", STATIC_GATEWAY)
+NET_IFACE = os.environ.get("PIKVM_NET_IFACE", "eth0")
+VLAN_IFACE = "vlan10"
 
 _network_template = Path(os.path.join(FILES, "eth0.network.j2")).read_text(
     encoding="utf-8",
 )
 _network_rendered = Template(_network_template, keep_trailing_newline=True).render(
-    iface=STATIC_IFACE,
-    address=STATIC_IP,
-    prefix=STATIC_PREFIX,
-    gateway=STATIC_GATEWAY,
-    dns_servers=[dns.strip() for dns in STATIC_DNS.split(",") if dns.strip()],
+    iface=NET_IFACE,
+    vlan=VLAN_IFACE,
 )
-NETWORK_REMOTE = f"/etc/systemd/network/{STATIC_IFACE}.network"
-
+NETWORK_REMOTE = f"/etc/systemd/network/{NET_IFACE}.network"
 _desired_network_sha = hashlib.sha256(_network_rendered.encode()).hexdigest()
-static_ip_needs_rw = (
+
+# The VLAN 10 device (netdev) and its static-address network are fixed-value static
+# assets (Management VLAN 10 -> 192.168.10.2/24), so they are shipped verbatim.
+VLAN_NETDEV_SRC = os.path.join(FILES, f"{VLAN_IFACE}.netdev")
+VLAN_NETDEV_REMOTE = f"/etc/systemd/network/{VLAN_IFACE}.netdev"
+VLAN_NETWORK_SRC = os.path.join(FILES, f"{VLAN_IFACE}.network")
+VLAN_NETWORK_REMOTE = f"/etc/systemd/network/{VLAN_IFACE}.network"
+
+network_needs_rw = (
     host.get_fact(Sha256File, path=NETWORK_REMOTE) != _desired_network_sha
+    or _file_out_of_sync(VLAN_NETDEV_REMOTE, VLAN_NETDEV_SRC)
+    or _file_out_of_sync(VLAN_NETWORK_REMOTE, VLAN_NETWORK_SRC)
 )
 
-with rootfs.writable(changed_if=static_ip_needs_rw):
+with rootfs.writable(changed_if=network_needs_rw):
     files.put(
-        name=f"Static IP: systemd-networkd config for {STATIC_IFACE}",
+        name=f"Network: {NET_IFACE} DHCP (untagged) + attach VLAN {VLAN_IFACE}",
         src=StringIO(_network_rendered),
         dest=NETWORK_REMOTE,
         mode="644",
     )
+    files.put(
+        name=f"Network: {VLAN_IFACE} netdev (802.1Q VLAN 10)",
+        src=VLAN_NETDEV_SRC,
+        dest=VLAN_NETDEV_REMOTE,
+        mode="644",
+    )
+    files.put(
+        name=f"Network: {VLAN_IFACE} static address 192.168.10.2/24",
+        src=VLAN_NETWORK_SRC,
+        dest=VLAN_NETWORK_REMOTE,
+        mode="644",
+    )
 
-if static_ip_needs_rw:
-    # rootfs is already ro (context exited); reconfigure re-reads the link config in
-    # place. networkctl has no pyinfra operation -> documented shell. With an unchanged
-    # address the SSH session survives.
+if network_needs_rw:
+    # rootfs is already ro (context exited); reload picks up the new .netdev/.network
+    # files (creating the vlan10 device) and reconfigure re-reads the link config in
+    # place. networkctl has no pyinfra operation -> documented shell. This re-requests the
+    # untagged DHCP lease and brings up VLAN 10 (see CONNECTIVITY RISK above).
     server.shell(
-        name="Static IP: reconfigure interface (rootfs already ro)",
+        name="Network: reload + reconfigure (DHCP untagged + VLAN 10 static)",
         commands=[
             "networkctl reload",
-            f"networkctl reconfigure {STATIC_IFACE}",
+            f"networkctl reconfigure {NET_IFACE}",
+            f"networkctl reconfigure {VLAN_IFACE}",
         ],
     )
 
@@ -623,16 +672,15 @@ if static_ip_needs_rw:
 #      destination (e.g. the Omada resource/peer). Without the route + policy NetBird does not
 #      distribute the network to this peer and traffic is dropped.
 #   2. LAN router: add a static route for the NetBird account block 100.65.0.0/16 -> this
-#      box's LAN IP (192.168.1.31), or push it via DHCP option 121, so LAN devices send
-#      mesh-bound traffic here. The SNAT rule below then rewrites their source to wt0.
+#      box's LAN IP (its DHCP lease; set a reservation so it is stable), or push it via DHCP
+#      option 121, so LAN devices send mesh-bound traffic here. The SNAT rule below then
+#      rewrites their source to wt0.
 #
-# LAN CIDR defaults to the network of the Task 8 static IP (single source of truth for this
-# box's LAN); the NetBird interface defaults to wt0. Both are overridable by env for reuse.
+# LAN CIDR defaults to 192.168.0.0/16 so the SNAT rule covers every home VLAN whose clients
+# reach the mesh through this box (legacy 192.168.1.0/24 today, 192.168.10/20/30/... after
+# the Omada cutover); the NetBird interface defaults to wt0. Both are overridable by env.
 
-ROUTING_LAN_CIDR = os.environ.get(
-    "PIKVM_LAN_CIDR",
-    str(ipaddress.ip_network(f"{STATIC_IP}/{STATIC_PREFIX}", strict=False)),
-)
+ROUTING_LAN_CIDR = os.environ.get("PIKVM_LAN_CIDR", "192.168.0.0/16")
 ROUTING_IFACE = os.environ.get("PIKVM_NETBIRD_IFACE", "wt0")
 
 ROUTING_SCRIPT_SRC = os.path.join(FILES, "setup-netbird-routing.sh")

--- a/apps/pikvm/files/eth0.network.j2
+++ b/apps/pikvm/files/eth0.network.j2
@@ -2,8 +2,5 @@
 Name={{ iface }}
 
 [Network]
-Address={{ address }}/{{ prefix }}
-Gateway={{ gateway }}
-{% for dns in dns_servers -%}
-DNS={{ dns }}
-{% endfor -%}
+DHCP=ipv4
+VLAN={{ vlan }}

--- a/apps/pikvm/files/goss.yaml
+++ b/apps/pikvm/files/goss.yaml
@@ -74,7 +74,17 @@ http:
       - '"agent-claimed":true'
       - '"aclk-available":true'
 
-# 7. /etc/resolv.conf routes ALL resolution through the systemd-resolved stub (127.0.0.53).
+# 7. The PiKVM port is a trunk: untagged/native traffic is DHCP and tagged VLAN 10
+#    (Management) carries the stable static address 192.168.10.2/24 on the vlan10 netdev.
+#    That static address is the Omada static-route next-hop + NetBird site-to-VPN path, so
+#    it must be present on the tagged interface (deploy.py Task 8 owns the networkd config).
+interface:
+  vlan10:
+    exists: true
+    addrs:
+      - 192.168.10.2/24
+
+# 8. /etc/resolv.conf routes ALL resolution through the systemd-resolved stub (127.0.0.53).
 #    Regression guard: this file was the root cause of goss's Go resolver querying the LAN
 #    router (192.168.1.1) and NXDOMAINing *.svc.cluster.local. It must be a real FILE (not
 #    the old resolved "uplink" symlink) whose nameserver is the stub -- so mesh/split-DNS

--- a/apps/pikvm/files/netbird@.service.d/pikvm.conf
+++ b/apps/pikvm/files/netbird@.service.d/pikvm.conf
@@ -16,3 +16,22 @@ ConfigurationDirectory=
 StateDirectory=
 LogsDirectory=
 Environment=NB_DISABLE_SSH_CONFIG=true
+
+# Sandbox relaxation so NetBird native-SSH sessions can manage the box.
+# NetBird's built-in SSH server spawns its login shells INSIDE this unit's systemd
+# sandbox, so `moon run pikvm:apply` (production/NetBird inventory) runs every operation
+# in that mount namespace. The stock unit's hardening breaks the apply there:
+#   * ProtectHome=yes masks /root as an inaccessible read-only tmpfs -- the very first
+#     slice fails with `mkdir /root/.ssh: Read-only file system`, and every /root write
+#     (netbird-state, netdata-state, password fingerprint) with it.
+#   * ProtectSystem=yes force-mounts /usr and /boot read-only on top of the partitions,
+#     so the writable_usr remount (goss/validate binaries under /usr/local/bin) cannot
+#     expose them.
+# Turning both off lets the `rw` rootfs remount (which DOES persist across the shared
+# session namespace) expose the real, writable directories, so the apply converges over
+# NetBird. This deliberately narrows the daemon's isolation on this box; acceptable
+# because netbird IS the trusted management plane here and native-SSH admin needs rootfs
+# write access. The rest of the stock hardening (NoNewPrivileges, ProtectKernel*,
+# RestrictNamespaces, PrivateTmp, ...) is left intact.
+ProtectHome=no
+ProtectSystem=no

--- a/apps/pikvm/files/setup-netbird-routing.sh
+++ b/apps/pikvm/files/setup-netbird-routing.sh
@@ -12,7 +12,7 @@ set -e
 # are injected by netbird-routing.service (Environment=), baked from the deploy; the defaults
 # match this box's LAN (see deploy.py Task 8/9).
 
-LAN_CIDR="${NB_ROUTING_LAN_CIDR:-192.168.1.0/24}"
+LAN_CIDR="${NB_ROUTING_LAN_CIDR:-192.168.0.0/16}"
 IFACE="${NB_ROUTING_IFACE:-wt0}"
 
 # Forward IPv4 between the LAN and the NetBird interface.

--- a/apps/pikvm/files/vlan10.netdev
+++ b/apps/pikvm/files/vlan10.netdev
@@ -1,0 +1,6 @@
+[NetDev]
+Name=vlan10
+Kind=vlan
+
+[VLAN]
+Id=10

--- a/apps/pikvm/files/vlan10.network
+++ b/apps/pikvm/files/vlan10.network
@@ -1,0 +1,5 @@
+[Match]
+Name=vlan10
+
+[Network]
+Address=192.168.10.2/24

--- a/apps/pikvm/inventories/production.py
+++ b/apps/pikvm/inventories/production.py
@@ -7,18 +7,93 @@ Default host is the PiKVM's NetBird IP. Override with ``PIKVM_HOST`` (e.g. the
 ``pikvm.netbird.cloud`` name if NetBird DNS is enabled on the client, or a new IP).
 Reaching it requires a NetBird access policy that permits your client to the PiKVM
 (both peers in a shared group) -- NetBird ACLs are managed in the dashboard, not here.
+
+NetBird SSH auth
+----------------
+Over the NetBird overlay the PiKVM's ``:22`` is NetBird's *own* SSH server, not OpenSSH.
+A connection goes through ``netbird ssh proxy`` -- which performs the JWT/SSO handshake via
+the local NetBird daemon's session -- and the SSH session then authenticates with the
+``none`` method (identity is already established by NetBird). pyinfra's paramiko transport
+does not speak this out of the box, so two shims (below) teach it to:
+
+1. A generated ssh_config pointing every host at ``ProxyCommand netbird ssh proxy``.
+   paramiko does not read ``/etc/ssh/ssh_config.d/*`` (where NetBird installs its own
+   ProxyCommand) and it hard-errors on unrelated ``IdentityFile`` directives in the user's
+   ``~/.ssh/config``, so we hand it a minimal config of our own.
+2. A paramiko ``_auth`` patch that tries the ``none`` method first. paramiko never attempts
+   ``none`` on its own (it raises "No authentication methods available"), which is exactly
+   why apply broke when the box moved to NetBird's JWT SSH. The patch is a no-op against a
+   normal OpenSSH server -- ``none`` is refused and it falls back to the standard chain --
+   so it is safe even though only this NetBird inventory needs it.
+
+Override the NetBird binary with ``NETBIRD_BIN`` if it is not on ``PATH``.
 """
 
 import os
+import shutil
+import tempfile
+
+import paramiko
+from paramiko.ssh_exception import SSHException
 
 PIKVM_HOST = os.environ.get("PIKVM_HOST", "100.65.192.152")
 PIKVM_SSH_USER = os.environ.get("PIKVM_SSH_USER", "root")
+
+
+def _netbird_binary() -> str:
+    """Locate a NetBird binary that can run ``netbird ssh proxy``."""
+    return (
+        os.environ.get("NETBIRD_BIN")
+        or shutil.which("netbird")
+        or "/Applications/NetBird.app/Contents/MacOS/netbird"
+    )
+
+
+def _write_ssh_config() -> str:
+    """Render a minimal ssh_config routing all hosts through the NetBird SSH proxy.
+
+    Written to a fixed path in the system temp dir (overwritten each run, never committed).
+    """
+    contents = (
+        "Host *\n"
+        f"    ProxyCommand {_netbird_binary()} ssh proxy %h %p\n"
+        "    StrictHostKeyChecking accept-new\n"
+        "    UserKnownHostsFile /dev/null\n"
+    )
+    config_path = os.path.join(tempfile.gettempdir(), "pikvm-netbird-ssh-config")
+    with open(config_path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+    return config_path
+
+
+# Shim 2: attempt the "none" auth method first (see module docstring). paramiko's
+# SSHClient._auth never tries it, so patch it to -- succeeding for NetBird SSH and falling
+# through to the normal chain (key/agent/password) for any server that refuses none.
+_original_auth = paramiko.client.SSHClient._auth
+
+
+def _auth_none_first(self, username, *args, **kwargs):
+    transport = self._transport
+    if transport is not None:
+        try:
+            transport.auth_none(username)
+        except SSHException:
+            pass  # none not offered/accepted -> fall back to the normal auth chain
+        if transport.is_authenticated():
+            return None
+    return _original_auth(self, username, *args, **kwargs)
+
+
+paramiko.client.SSHClient._auth = _auth_none_first
+
 
 hosts = [
     (
         PIKVM_HOST,
         {
             "ssh_user": PIKVM_SSH_USER,
+            # Route paramiko through `netbird ssh proxy` (JWT/SSO handled by the daemon).
+            "ssh_config_file": _write_ssh_config(),
             # accept-new: auto-trust a fresh box's key, still refuse a changed one.
             "ssh_strict_host_key_checking": "accept-new",
         },

--- a/libs/pyinfra-custom/src/pyinfra_custom/facts/__init__.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/facts/__init__.py
@@ -3,7 +3,8 @@
 - :class:`~pyinfra_custom.facts.openbao.OpenBaoSecret` — one OpenBao KV field, fetched
   via the ``hvac`` SDK on the control machine (never transmitted to the target host).
 - :mod:`~pyinfra_custom.facts.netbird` — NetBird client state (version / connected /
-  DNS / SSH server / SSH root), each guarded by ``requires_command('netbird')``.
+  DNS / SSH server / SSH root / SSH SFTP), each guarded by
+  ``requires_command('netbird')``.
 - :class:`~pyinfra_custom.facts.pacman.PacmanUpgradablePackages` — upgradable packages,
   guarded by ``requires_command('pacman')``.
 - :class:`~pyinfra_custom.facts.goss.GossVersion` — installed goss version, guarded by
@@ -18,6 +19,7 @@ from pyinfra_custom.facts.netbird import (
     NetbirdDnsDisabled,
     NetbirdServerSshAllowed,
     NetbirdSshRootEnabled,
+    NetbirdSshSftpEnabled,
     NetbirdVersion,
 )
 from pyinfra_custom.facts.netdata import NetdataVersion
@@ -30,6 +32,7 @@ __all__ = [
     "NetbirdDnsDisabled",
     "NetbirdServerSshAllowed",
     "NetbirdSshRootEnabled",
+    "NetbirdSshSftpEnabled",
     "NetbirdVersion",
     "NetdataVersion",
     "OpenBaoSecret",

--- a/libs/pyinfra-custom/src/pyinfra_custom/facts/netbird.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/facts/netbird.py
@@ -112,3 +112,28 @@ class NetbirdSshRootEnabled(FactBase[bool]):
 
     def process(self, output: list[str]) -> bool:
         return any("true" in line.lower() for line in output)
+
+
+class NetbirdSshSftpEnabled(FactBase[bool]):
+    """``True`` when NetBird's persisted config has ``EnableSSHSFTP: true``.
+
+    Drives the SFTP-enable reconcile. The native SSH server serves no SFTP subsystem by
+    default, so ``pyinfra``'s ``files.put`` (an SFTP upload) fails with "Unable to
+    establish SFTP connection" whenever management runs OVER the NetBird SSH server and a
+    file actually needs transferring. Returns ``False`` before registration (the config
+    file does not exist yet), matching "SFTP not enabled".
+    """
+
+    default = bool  # bool() -> False
+
+    def requires_command(self, *args, **kwargs) -> str:
+        return "netbird"
+
+    def command(self) -> str:
+        return (
+            "grep -o '\"EnableSSHSFTP\"[^,]*' /var/lib/netbird/default.json "
+            "2>/dev/null || true"
+        )
+
+    def process(self, output: list[str]) -> bool:
+        return any("true" in line.lower() for line in output)

--- a/libs/pyinfra-custom/src/pyinfra_custom/operations/netbird.py
+++ b/libs/pyinfra-custom/src/pyinfra_custom/operations/netbird.py
@@ -11,6 +11,7 @@ def up(
     disable_dns: bool = False,
     allow_server_ssh: bool = False,
     enable_ssh_root: bool = False,
+    enable_ssh_sftp: bool = False,
 ):
     """Run ``netbird up`` to register / (re)connect the peer.
 
@@ -28,6 +29,10 @@ def up(
         enable_ssh_root: passed through as ``--enable-ssh-root=<true|false>`` to permit
             root login on the native SSH server. Only meaningful when ``allow_server_ssh``
             is ``True``; likewise persisted (``EnableSSHRoot``), so set explicitly.
+        enable_ssh_sftp: passed through as ``--enable-ssh-sftp=<true|false>`` to serve the
+            SFTP subsystem on the native SSH server. Required for ``pyinfra``'s
+            ``files.put`` (which uploads over SFTP) to work when management runs OVER the
+            NetBird SSH server. Persisted as ``EnableSSHSFTP``, so set explicitly.
 
     Not idempotent: ``netbird up`` on an already-connected peer is itself a no-op, but
     pyinfra cannot know that, so callers gate this with ``_if`` / a connected fact.
@@ -35,10 +40,12 @@ def up(
     dns_flag = "true" if disable_dns else "false"
     ssh_flag = "true" if allow_server_ssh else "false"
     ssh_root_flag = "true" if enable_ssh_root else "false"
+    ssh_sftp_flag = "true" if enable_ssh_sftp else "false"
     args = (
         f"--disable-dns={dns_flag} "
         f"--allow-server-ssh={ssh_flag} "
-        f"--enable-ssh-root={ssh_root_flag}"
+        f"--enable-ssh-root={ssh_root_flag} "
+        f"--enable-ssh-sftp={ssh_sftp_flag}"
     )
     if setup_key is not None:
         yield StringCommand(

--- a/libs/pyinfra-custom/tests/test_operations.py
+++ b/libs/pyinfra-custom/tests/test_operations.py
@@ -26,6 +26,7 @@ def test_netbird_up_with_setup_key_uses_env_not_argv():
     # SSH flags default off and are always emitted explicitly.
     assert "--allow-server-ssh=false" in raw
     assert "--enable-ssh-root=false" in raw
+    assert "--enable-ssh-sftp=false" in raw
 
 
 def test_netbird_up_without_setup_key_has_no_env():
@@ -35,7 +36,8 @@ def test_netbird_up_without_setup_key_has_no_env():
     assert cmd.connector_arguments.get("_env") is None
     assert cmd.get_raw_value() == (
         "netbird up --disable-dns=false "
-        "--allow-server-ssh=false --enable-ssh-root=false"
+        "--allow-server-ssh=false --enable-ssh-root=false "
+        "--enable-ssh-sftp=false"
     )
 
 
@@ -43,7 +45,8 @@ def test_netbird_up_disable_dns_true():
     commands = list(netbird.up._inner(setup_key=None, disable_dns=True))
     assert commands[0].get_raw_value() == (
         "netbird up --disable-dns=true "
-        "--allow-server-ssh=false --enable-ssh-root=false"
+        "--allow-server-ssh=false --enable-ssh-root=false "
+        "--enable-ssh-sftp=false"
     )
 
 
@@ -54,11 +57,13 @@ def test_netbird_up_allow_server_ssh_and_root():
             disable_dns=False,
             allow_server_ssh=True,
             enable_ssh_root=True,
+            enable_ssh_sftp=True,
         )
     )
     assert commands[0].get_raw_value() == (
         "netbird up --disable-dns=false "
-        "--allow-server-ssh=true --enable-ssh-root=true"
+        "--allow-server-ssh=true --enable-ssh-root=true "
+        "--enable-ssh-sftp=true"
     )
 
 


### PR DESCRIPTION
## What

Reconfigures the PiKVM port as a **trunk** and makes `moon run pikvm:apply` work end-to-end over the NetBird native-SSH server.

### Network (Task 8)
- `eth0.network.j2`: `DHCP=ipv4` on the untagged/native VLAN **+** `VLAN=vlan10`
- `vlan10.netdev` / `vlan10.network` (new): 802.1Q id 10, static **`192.168.10.2/24`** (no gateway — untagged DHCP owns the default route)
- `deploy.py`: installs all three networkd files (sha-gated), then `networkctl reload` + `reconfigure eth0 vlan10`
- `goss.yaml`: asserts `vlan10` carries `192.168.10.2/24`

### Making apply-over-NetBird work
NetBird's native-SSH server spawns shells **inside the `netbird@netbird.service` systemd sandbox**, which broke the apply in two ways:
- **`ProtectHome=yes`/`ProtectSystem=yes`** masked `/root` as an inaccessible ro tmpfs and forced `/usr`,`/boot` ro → every `rootfs.writable` slice failed (`mkdir /root/.ssh: Read-only file system`). Drop-in now sets `ProtectHome=no` + `ProtectSystem=no`. **The rootfs itself stays read-only at rest** — this only governs what the SSH session's mount namespace can see.
- **No SFTP subsystem** → pyinfra's `files.put` (SFTP) failed with "Unable to establish SFTP connection". Added `netbird up --enable-ssh-sftp` (new `enable_ssh_sftp` arg + `NetbirdSshSftpEnabled` fact) wired into the Task-6 reconcile.
- `inventories/production.py`: ssh_config `ProxyCommand netbird ssh proxy` + paramiko `none`-auth shim.
- `setup-netbird-routing.sh`: default `LAN_CIDR=192.168.0.0/16` (covers all VLANs).

### Docs
- `apps/network/network.md`: Omada home-network target-config reference.

## Verification (live, over NetBird)
- Full apply: **46 ops / 0 errors**
- `eth0` untagged DHCP → `192.168.1.40/24`; `vlan10@eth0` UP with **`192.168.10.2/24`** (both routable)
- **goss 24/24 pass** (incl. new `vlan10` check + Omada cross-cluster checks)
- `--dry` re-run fully converged (0 changes); `/proc/1/mountinfo` shows `/` `ro` at rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)